### PR TITLE
Removed warning from cv_measure()

### DIFF
--- a/c2qa/circuit.py
+++ b/c2qa/circuit.py
@@ -751,11 +751,6 @@ class CVCircuit(QuantumCircuit):
         Returns:
             Instruction: QisKit measure instruction
         """
-        if not self.probe_measure:
-            warnings.warn(
-                "Probe qubits not in use, set probe_measure to True for measure support.",
-                UserWarning,
-            )
 
         # Flattens the list (if necessary)
         flat_list = []


### PR DESCRIPTION
There was a warning being printed within cv_measure having to do with probe_measure not being True. Removed as probe qubits are not used within cv_measure.