### PR TITLE
Functions for adding arbitrary unitary matrices to bosonic qiskit circuits, and a rework of cv_fockcounts

### DIFF
--- a/c2qa/circuit.py
+++ b/c2qa/circuit.py
@@ -831,7 +831,9 @@ class CVCircuit(QuantumCircuit):
         )
 
     def cv_gate_from_matrix(self, matrix, qumodes=[], qubits=[], duration=100, unit="ns"):
-        """Converts matrix to gate.
+        """Converts matrix to gate. Note that if you choose to feed a single mega-matrix that would have been physically 
+        implemented by multiple successive gate operations, PhotonLossNoisePass, simulate(discretize=True), and animate will 
+        not be applied in a way that is physical.
 
         Args:
             matrix (np.array/nested list): Matrix for conversion into gate

--- a/c2qa/circuit.py
+++ b/c2qa/circuit.py
@@ -136,6 +136,32 @@ class CVCircuit(QuantumCircuit):
 
         return indices
 
+    @property
+    def qumode_qubits_indices_grouped(self):
+        """Same as qumode_qubit_indices but it groups qubits representing the same qumode together. Returns a nested list."""
+        grouped_indices = []
+    
+        # Iterate through all qmregs
+        for _, qmreg in enumerate(self.qmregs):
+            num_qumodes_in_reg = qmreg.num_qumodes
+            num_qubits_per_qumode = qmreg.num_qubits_per_qumode
+
+            qmreg_qubit_indices = []
+
+            # For every qubit in circuit, append index of qubit to list if qubit is in qmreg
+            for qubit_index, qubit in enumerate(self.qubits): 
+                if qubit in qmreg[:]:
+                    qmreg_qubit_indices.append(qubit_index)
+
+            # Split list according to no. of qumodes in qmreg
+            qmreg_qubit_indices = [qmreg_qubit_indices[i * num_qubits_per_qumode: (i + 1) * num_qubits_per_qumode] for i in range(num_qumodes_in_reg)]
+
+            # Extend final list
+            grouped_indices.extend(qmreg_qubit_indices) 
+
+        return(grouped_indices)        
+         
+
     def get_qubit_index(self, qubit):
         """Return the index of the given Qubit"""
         for i, q in enumerate(self.qubits):
@@ -813,9 +839,9 @@ class CVCircuit(QuantumCircuit):
         """Converts matrix to gate.
 
         Args:
-            matrix (np.array/list): Matrix for conversion into gate
+            matrix (np.array/nested list): Matrix for conversion into gate
             qumodes (QumodeRegister/list): Qumodes initialized by QumodeRegister
-            qubits (QuantumRegister/list): Qubits initialized by QuantumRegister <-double check
+            qubits (QuantumRegister/list): Qubits initialized by QuantumRegister
 
         Returns:
             Instruction: QisKit instruction

--- a/c2qa/operators.py
+++ b/c2qa/operators.py
@@ -418,3 +418,12 @@ class CVOperators:
         print(max)
 
         return self.eye
+
+    def gate_from_matrix(self, matrix):
+        """Converts matrix into gate. Called using ParameterizedUnitaryGate.
+        Args:
+            matrix (list): the (unitary) matrix that you wish to convert into a gate
+        Returns:
+            csc_matrix: operator matrix
+        """ 
+        return scipy.sparse.csc_matrix(matrix)

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -404,7 +404,6 @@ def get_probabilities(result: qiskit.result.Result):
 def simulate(
     circuit: CVCircuit,
     shots: int = 1024,
-    return_fockcounts: bool = False,
     add_save_statevector: bool = True,
     conditional_state_vector: bool = False,
     per_shot_state_vector: bool = False,
@@ -419,7 +418,6 @@ def simulate(
     Args:
         circuit (CVCircuit): circuit to simulate
         shots (int, optional): Number of simulation shots. Defaults to 1024.
-        return_fockcounts (bool, optional): Set to True if measurement results should be returned. Defaults to False
         add_save_statevector (bool, optional): Set to True if a state_vector instruction
                                                should be added to the end of the circuit. Defaults to True.
         conditional_state_vector (bool, optional): Set to True if the saved state vector should be contional
@@ -468,14 +466,6 @@ def simulate(
 
     if add_save_statevector:
         circuit.data.pop()  # Clean up by popping off the SaveStatevector instruction
-
-    # Print counts
-    if return_fockcounts:
-        try:
-            fockcounts = newcounts(circuit, result)
-            return state, result, fockcounts
-        except:
-            Exception("newcounts() was not able to execute")
 
     return state, result
 

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -510,7 +510,7 @@ def simulate(
             continue
 
         previous_state = state
-        results.append((state, result))
+        results.append((state, result, None))
 
     if discretize:
         return results

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -206,7 +206,7 @@ def cv_fockcounts(counts, qubit_qumode_list, reverse_endianness=False):
          qumodes in qubit_qumode_list in little endian order, with Fock-basis
          qumode measurements reported as a base-10 integer.
     """
-    warnings.warn("The function ``c2qa.util.cv_fockcounts()`` is deprecated as of bosonic-qiskit v8.2. The function is replaced by counts_to_fockcounts(), which can be called using simulate().")
+    warnings.warn("The function ``c2qa.util.cv_fockcounts()`` is deprecated as of bosonic-qiskit v8.2. The function is replaced by counts_to_fockcounts(), which can be called using util.simulate().")
 
     flat_list = []
     for el in qubit_qumode_list:

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -234,6 +234,24 @@ def cv_fockcounts(counts, qubit_qumode_list, reverse_endianness=False):
     return newcounts
 
 
+
+
+def _final_qumode_mapping(circuit):
+    """
+    Return the classical bits that active qumode qubits are mapped onto. Bits corresponding to distinct qumodes are grouped together
+    """
+    final_measurement_mapping = _final_measurement_mapping(circuit)
+    active_qumode_bit_indices_grouped = []
+
+    # For each qumode qubit group, extract list of bits that map to qubits in group. Append list only if list is not empty
+    for qumode_qubit_group in circuit.qumode_qubits_indices_grouped:
+        qumode_bit_group = [key for key, val in final_measurement_mapping.items() for qubit in qumode_qubit_group if val == qubit]
+        
+        if qumode_bit_group != []:
+            active_qumode_bit_indices_grouped.append(qumode_bit_group)
+
+    return active_qumode_bit_indices_grouped
+
     
 # This code is part of Mthree.
 #

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -432,7 +432,7 @@ def simulate(
         discretize (bool, optional): Set to True if circuit should be discretized to apply noise passes. Defaults to False.
 
     Returns:
-        tuple: (state, result) tuple from simulation
+        tuple: (state, result, fockcounts) tuple from simulation
     """
 
     if discretize and not noise_passes:

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -63,7 +63,7 @@ def stateread(
     stateop, numberofqubits, numberofmodes, cutoff, verbose=True, little_endian=False
 ):
     """Print values for states of qubits and qumodes using the result of a
-    simulation of the statevector, e.g. using stateop, _ = c2qa.util.simulate(circuit).
+    simulation of the statevector, e.g. using stateop, _, _ = c2qa.util.simulate(circuit).
 
     Returns the states of the qubits and the Fock states of the qumodes with respective amplitudes.
     """

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -206,6 +206,7 @@ def cv_fockcounts(counts, qubit_qumode_list, reverse_endianness=False):
          qumodes in qubit_qumode_list in little endian order, with Fock-basis
          qumode measurements reported as a base-10 integer.
     """
+    warnings.warn("The function ``c2qa.util.cv_fockcounts()`` is deprecated as of bosonic-qiskit v8.2. The function is replaced by counts_to_fockcounts(), which can be called using simulate().")
 
     flat_list = []
     for el in qubit_qumode_list:

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -48,7 +48,7 @@ def cv_ancilla_fock_measure(circuit,list_qumodes_to_sample:list, qmr_number:int=
         circuit.barrier()
         qumode_counter+=1
     # Simulate circuit with a single shot
-    _, result = simulate(circuit, shots=1)
+    _, result, _ = simulate(circuit, shots=1)
     # Return integer value of boson number occupation, converted from the bits which make up a binary number
     print(result.get_counts())
     full_set_of_binary = list(result.get_counts().keys())[0].encode('ascii')

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -256,14 +256,13 @@ def newcounts(circuit: CVCircuit, result: qiskit.result.result.Result):
         max_iter_index = len(key) - 1
         newkey = key
 
+        # Using the nested list of qumode bit mappings, convert the relevant bits to base-10 integer and 
+        # form new key by concatenating the unchanged bits of key around the decimal value.
         for index in range(len(key)):
             for qumode in qumode_bit_mapping:
-                if (max_iter_index - index) == min(qumode):
+                if index == min(qumode):
                     fock_decimal = str(int(key[max_iter_index - max(qumode) : max_iter_index - min(qumode) + 1], base=2))
                     newkey = newkey[: max_iter_index - max(qumode)] + fock_decimal + newkey[max_iter_index - min(qumode) + 1: ]
-                    
-                elif not (index in qumode):
-                    pass
 
         newcounts[newkey] = counts[key]
 
@@ -283,6 +282,9 @@ def _final_qumode_mapping(circuit):
         
         if qumode_bit_group != []:
             active_qumode_bit_indices_grouped.append(qumode_bit_group)
+
+    # Sort nested list by first item in each sublist
+    active_qumode_bit_indices_grouped = sorted(active_qumode_bit_indices_grouped, key = lambda l: l[0])
 
     return active_qumode_bit_indices_grouped
 

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -238,7 +238,7 @@ def cv_fockcounts(counts, qubit_qumode_list, reverse_endianness=False):
     return newcounts
 
 
-def newcounts(circuit: CVCircuit, result: qiskit.result.result.Result):
+def counts_to_fockcounts(circuit: CVCircuit, result: qiskit.result.result.Result):
     """Convert counts dictionary from Fock-basis binary representation into
     base-10 Fock basis (qubit measurements are left unchanged). Accepts the object returned by
     jobs.result(), along with the entire circuit.
@@ -501,9 +501,9 @@ def simulate(
 
         if return_fockcounts:
             try:
-                fockcounts = newcounts(circuit, result)
+                fockcounts = counts_to_fockcounts(circuit, result)
             except:
-                Exception("newcounts() was not able to execute")
+                Exception("counts_to_fockcounts() was not able to execute")
             
             previous_state = state
             results.append((state, result, fockcounts))

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -356,33 +356,33 @@ def _final_measurement_mapping(circuit):
 def measure_all_xyz(circuit: qiskit.QuantumCircuit):
     """Use QuantumCircuit.measure_all() to measure all qubits in the X, Y, and Z basis.
 
-    Returns state, result tuples each for the X, Y, and Z basis.
+    Returns state, result, fockcounts tuples each for the X, Y, and Z basis.
 
     Args:
         circuit (qiskit.QuantumCircuit): circuit to measure qubits one
 
     Returns:
-        x,y,z state & result tuples: (state, result) tuples for each x,y,z measurements
+        x,y,z state & result tuples: (state, result, fockcounts) tuples for each x,y,z measurements
     """
 
     # QuantumCircuit.measure_all(False) returns a copy of the circuit with measurement gates.
     circuit_z = circuit.measure_all(False)
-    state_z, result_z = simulate(circuit_z)
+    state_z, result_z, fockcounts_z = simulate(circuit_z)
 
     circuit_x = circuit.copy()
     for qubit in circuit_x.qubits:
         circuit_x.h(qubit)
     circuit_x.measure_all()  # Add measure gates in-place
-    state_x, result_x = simulate(circuit_x)
+    state_x, result_x, fockcounts_x = simulate(circuit_x)
 
     circuit_y = circuit.copy()
     for qubit in circuit_y.qubits:
         circuit_y.sdg(qubit)
         circuit_y.h(qubit)
     circuit_y.measure_all()  # Add measure gates in-place
-    state_y, result_y = simulate(circuit_y)
+    state_y, result_y, fockcounts_y = simulate(circuit_y)
 
-    return (state_x, result_x), (state_y, result_y), (state_z, result_z)
+    return (state_x, result_x, fockcounts_x), (state_y, result_y, fockcounts_y), (state_z, result_z, fockcounts_z)
 
 
 def get_probabilities(result: qiskit.result.Result):

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -503,9 +503,13 @@ def simulate(
                 fockcounts = newcounts(circuit, result)
             except:
                 Exception("newcounts() was not able to execute")
+            
+            previous_state = state
+            results.append((state, result, fockcounts))
+            continue
 
         previous_state = state
-        results.append((state, result, fockcounts))
+        results.append((state, result))
 
     if discretize:
         return results

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -402,6 +402,7 @@ def get_probabilities(result: qiskit.result.Result):
 def simulate(
     circuit: CVCircuit,
     shots: int = 1024,
+    counts: bool = False,
     add_save_statevector: bool = True,
     conditional_state_vector: bool = False,
     per_shot_state_vector: bool = False,
@@ -464,6 +465,15 @@ def simulate(
 
     if add_save_statevector:
         circuit.data.pop()  # Clean up by popping off the SaveStatevector instruction
+
+    # Print counts
+    if counts:
+        try:
+            counts = cv_newcounts(circuit, result)
+            print(counts)
+            return state, result, counts
+        except:
+            Exception("cv_newcounts was not able to execute")
 
     return state, result
 

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -408,7 +408,7 @@ def get_probabilities(result: qiskit.result.Result):
 def simulate(
     cvcircuit: CVCircuit,
     shots: int = 1024,
-    return_fockcounts: bool = False,
+    return_fockcounts: bool = True,
     add_save_statevector: bool = True,
     conditional_state_vector: bool = False,
     per_shot_state_vector: bool = False,

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -404,7 +404,7 @@ def get_probabilities(result: qiskit.result.Result):
 def simulate(
     circuit: CVCircuit,
     shots: int = 1024,
-    counts: bool = False,
+    return_fockcounts: bool = False,
     add_save_statevector: bool = True,
     conditional_state_vector: bool = False,
     per_shot_state_vector: bool = False,
@@ -419,6 +419,7 @@ def simulate(
     Args:
         circuit (CVCircuit): circuit to simulate
         shots (int, optional): Number of simulation shots. Defaults to 1024.
+        return_fockcounts (bool, optional): Set to True if measurement results should be returned. Defaults to False
         add_save_statevector (bool, optional): Set to True if a state_vector instruction
                                                should be added to the end of the circuit. Defaults to True.
         conditional_state_vector (bool, optional): Set to True if the saved state vector should be contional
@@ -469,11 +470,10 @@ def simulate(
         circuit.data.pop()  # Clean up by popping off the SaveStatevector instruction
 
     # Print counts
-    if counts:
+    if return_fockcounts:
         try:
-            counts = newcounts(circuit, result)
-            print(counts)
-            return state, result, counts
+            fockcounts = newcounts(circuit, result)
+            return state, result, fockcounts
         except:
             Exception("newcounts() was not able to execute")
 

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -234,7 +234,7 @@ def cv_fockcounts(counts, qubit_qumode_list, reverse_endianness=False):
     return newcounts
 
 
-def cv_newcounts(circuit: CVCircuit, result: qiskit.result.result.Result):
+def newcounts(circuit: CVCircuit, result: qiskit.result.result.Result):
     """Convert counts dictionary from Fock-basis binary representation into
     base-10 Fock basis (qubit measurements are left unchanged). Accepts the object returned by
     jobs.result(), along with the entire circuit.
@@ -469,11 +469,11 @@ def simulate(
     # Print counts
     if counts:
         try:
-            counts = cv_newcounts(circuit, result)
+            counts = newcounts(circuit, result)
             print(counts)
             return state, result, counts
         except:
-            Exception("cv_newcounts was not able to execute")
+            Exception("newcounts() was not able to execute")
 
     return state, result
 

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -407,6 +407,7 @@ def get_probabilities(result: qiskit.result.Result):
 def simulate(
     cvcircuit: CVCircuit,
     shots: int = 1024,
+    return_fockcounts: bool = False,
     add_save_statevector: bool = True,
     conditional_state_vector: bool = False,
     per_shot_state_vector: bool = False,
@@ -422,6 +423,7 @@ def simulate(
     Args:
         circuit (CVCircuit): circuit to simulate
         shots (int, optional): Number of simulation shots. Defaults to 1024.
+        return_fockcounts (bool, optional): Set to True if measurement results should be returned. Defaults to False
         add_save_statevector (bool, optional): Set to True if a state_vector instruction
                                                should be added to the end of the circuit. Defaults to True.
         conditional_state_vector (bool, optional): Set to True if the saved state vector should be contional
@@ -496,8 +498,14 @@ def simulate(
         if add_save_statevector:
             sim_circuit.data.pop()  # Clean up by popping off the SaveStatevector instruction
 
+        if return_fockcounts:
+            try:
+                fockcounts = newcounts(circuit, result)
+            except:
+                Exception("newcounts() was not able to execute")
+
         previous_state = state
-        results.append((state, result))
+        results.append((state, result, fockcounts))
 
     if discretize:
         return results

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -520,7 +520,7 @@ def fockmap(matrix, fock_input, fock_output, amplitude=[]):
         raise ValueError("Fock state(s) greater than cutoff.")
 
     ## Use cases
-    # Int + int datatype for input/output args.
+    # 1. Int + int datatype for input/output args.
     if ((len(fock_input) == 1) & (len(fock_output) == 1)):
         if len(amplitude) > 1:
             raise ValueError("Please ensure that only a single amplitude value is provided, as there is only 1 mapping provided")
@@ -531,7 +531,7 @@ def fockmap(matrix, fock_input, fock_output, amplitude=[]):
 
         return matrix
 
-    # Int + list datatype for input/output args. Length of amplitude must match length of list
+    # 2. Int + list datatype for input/output args. Length of amplitude must match length of list
     elif (len(fock_input) == 1) & (len(fock_output) > 1):
         for i in range(len(fock_output)):
             if matrix[fock_output[i], fock_input[0]] != 0:
@@ -550,7 +550,7 @@ def fockmap(matrix, fock_input, fock_output, amplitude=[]):
 
         return matrix        
 
-    # List datatype input/output/amp args. Lengths of all must match
+    # 3. List datatype input/output/amp args. Lengths of all must match
     elif (len(fock_input) == len(fock_output) == len(amplitude)):
 
         for i in range(len(fock_input)):

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -507,10 +507,9 @@ def simulate(
             
             previous_state = state
             results.append((state, result, fockcounts))
-            continue
-
-        previous_state = state
-        results.append((state, result, None))
+        else:
+            previous_state = state
+            results.append((state, result, None))
 
     if discretize:
         return results

--- a/c2qa/wigner.py
+++ b/c2qa/wigner.py
@@ -24,7 +24,7 @@ def simulate_wigner(
     trace: bool = False,
 ):
     """Simulate the circuit, optionally partial trace the results, and calculate the Wigner function."""
-    states, _ = simulate(
+    states, _, _ = simulate(
         circuit,
         shots=shots,
         noise_passes=noise_passes,
@@ -64,7 +64,7 @@ def simulate_wigner_multiple_statevectors(
     trace: bool = False,
 ):
     """Simulate the circuit, optionally partial trace the results, and calculate the Wigner function on each statevector starting with the given label."""
-    state, result = simulate(
+    state, result, _ = simulate(
         circuit,
         shots=shots,
         noise_passes=noise_passes
@@ -310,12 +310,12 @@ def plot_wigner_projection(circuit: CVCircuit, qubit, file: str = None, draw_gri
         draw_grid (bool, optional): True if gridlines should be drawn on plots. Defaults to False.
     """
     # Get unaltered state vector and partial trace
-    x, _ = simulate(circuit)
+    x, _, _ = simulate(circuit)
     xT = x.data.conjugate().transpose()
 
     # Project onto 0 and 1 using Pauli Z
     circuit.z(qubit)
-    y, _ = simulate(circuit)
+    y, _, _ = simulate(circuit)
     yT = y.data.conjugate().transpose()
 
     x_xT = x.data * xT
@@ -336,7 +336,7 @@ def plot_wigner_projection(circuit: CVCircuit, qubit, file: str = None, draw_gri
 
     # Project onto + and - using Pauli X
     circuit.x(qubit)
-    y, _ = simulate(circuit)
+    y, _, _ = simulate(circuit)
     yT = y.data.conjugate().transpose()
 
     x_xT = x.data * xT

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -147,3 +147,85 @@ def test_serialize(capsys):
         print('\nAttempt to serialize an unbound CVCircuit:')
         bosonic_serial = json.dumps(bosonic_circuit, cls=RuntimeEncoder)
         print(bosonic_serial)
+
+def test_cv_gate_from_matrix(capsys):
+    with capsys.disabled():
+        # This test picks random qumode/qubit to initialize xgate on, does fockcounts, and checks that results match expected values.
+        xgate = [[0, 1],[1, 0]] # For qubit, flips |1> to |0> and vice versa. For qumode, flips fock |1> to fock |0> and vice versa
+        
+        num_qumode_registers = 2
+        num_qumodes_per_register = 2
+        num_qubits_per_qumode = 1
+
+        num_qubits = 3
+
+        total_qubits = num_qumode_registers * num_qumodes_per_register * num_qubits_per_qumode + num_qubits
+        for i in range(10): # Repeat test 10 times
+            # Two qumode registers, One quantum register, One classical register. Hilbert space dimension = 2**(2 * 2 * 1 + 3) = 128
+            qmr1 = c2qa.QumodeRegister(num_qumodes_per_register, num_qubits_per_qumode)
+            qmr2 = c2qa.QumodeRegister(num_qumodes_per_register, num_qubits_per_qumode)
+            q = qiskit.QuantumRegister(num_qubits)
+            creg = qiskit.ClassicalRegister(total_qubits)
+
+            # Initialize all qumodes to fock |1> and all qubits to |1> state
+            circuit = c2qa.CVCircuit(qmr1, qmr2, q, creg)
+            circuit.cv_initialize([0, 1], qmr1)
+            circuit.cv_initialize([0, 1], qmr2)
+
+            for i in range(num_qubits):
+                circuit.initialize([0, 1], q[i])
+            
+            # Pick one of the qumode registers to act on
+            register = numpy.random.randint(1, 3)
+
+            # Pick one of the qumodes to act on
+            qumode_no = numpy.random.randint(0, 2)
+
+            # Pick one of the qubits to act on
+            qubit_no = numpy.random.randint(0, 3)
+
+            # Create string corresponding to expected results
+            expect = ['1' for _ in range(total_qubits)]
+
+            if register == 1:
+                expect[qumode_no] = '0'
+            elif register == 2:
+                expect[qumode_no + 2] = '0'
+
+            expect[4 + qubit_no] = '0' 
+
+            expect = ''.join(reversed(expect))
+
+            # Depending on quantum register chosen, assert result to be true
+            if register == 1:
+                circuit.cv_gate_from_matrix(xgate, qumodes=qmr1[qumode_no])
+                circuit.cv_gate_from_matrix(xgate, qubits=q[qubit_no])
+
+                circuit.cv_measure(qmr1[:] + qmr2[:] + q[:], creg)
+
+                _, result = c2qa.util.simulate(circuit)
+                fock_counts = c2qa.util.cv_fockcounts(result.get_counts(), [qmr1[0], qmr1[1], qmr2[0], qmr2[1], q[0], q[1], q[2]])
+
+                # There should only be 1 result
+                if len(list(fock_counts.keys())) > 1:
+                    raise Exception
+
+                assert(list(fock_counts.keys())[0] == expect)
+
+            elif register == 2:
+                circuit.cv_gate_from_matrix(xgate, qmr2[qumode_no])
+                circuit.cv_gate_from_matrix(xgate, qubits=q[qubit_no])
+
+                circuit.cv_measure(qmr1[:] + qmr2[:] + q[:], creg)
+
+                _, result = c2qa.util.simulate(circuit)
+                fock_counts = c2qa.util.cv_fockcounts(result.get_counts(), [qmr1[0], qmr1[1], qmr2[0], qmr2[1], q[0], q[1], q[2]])
+
+                # There should only be 1 result
+                if len(list(fock_counts.keys())) > 1:
+                    raise Exception
+
+                assert(list(fock_counts.keys())[0] == expect)
+
+            else:
+                raise Exception

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -235,8 +235,6 @@ def test_cv_gate_from_matrix(capsys):
 
 def test_cv_initialize(capsys):
     with capsys.disabled():
-        import c2qa
-
         qmr1 = c2qa.QumodeRegister(1, 2)
         qmr2 = c2qa.QumodeRegister(2, 2)
         qmr3 = c2qa.QumodeRegister(2, 3) # <----- change to (2, 2) for no error
@@ -253,5 +251,5 @@ def test_cv_initialize(capsys):
         circuit.cv_initialize([0, 1], qmr6[0])
 
         # saving a state vector for all the registers takes a considerable amount of time
-        state, result, _ = c2qa.util.simulate(circuit, add_save_statevector=False)
+        state, result, _ = c2qa.util.simulate(circuit, add_save_statevector=False, return_fockcounts=False)
         assert result.success

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -253,5 +253,5 @@ def test_cv_initialize(capsys):
         circuit.cv_initialize([0, 1], qmr6[0])
 
         # saving a state vector for all the registers takes a considerable amount of time
-        state, result = c2qa.util.simulate(circuit, add_save_statevector=False)
+        state, result, _ = c2qa.util.simulate(circuit, add_save_statevector=False)
         assert result.success

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -203,7 +203,7 @@ def test_cv_gate_from_matrix(capsys):
 
                 circuit.cv_measure(qmr1[:] + qmr2[:] + q[:], creg)
 
-                _, result = c2qa.util.simulate(circuit)
+                _, result, _ = c2qa.util.simulate(circuit)
                 fock_counts = c2qa.util.cv_fockcounts(result.get_counts(), [qmr1[0], qmr1[1], qmr2[0], qmr2[1], q[0], q[1], q[2]])
 
                 # There should only be 1 result
@@ -218,7 +218,7 @@ def test_cv_gate_from_matrix(capsys):
 
                 circuit.cv_measure(qmr1[:] + qmr2[:] + q[:], creg)
 
-                _, result = c2qa.util.simulate(circuit)
+                _, result, _ = c2qa.util.simulate(circuit)
                 fock_counts = c2qa.util.cv_fockcounts(result.get_counts(), [qmr1[0], qmr1[1], qmr2[0], qmr2[1], q[0], q[1], q[2]])
 
                 # There should only be 1 result

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -56,7 +56,7 @@ def test_with_initialize():
 
     circuit.initialize(numpy.array([0, 1]), qbr[0])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert result.success
 
 
@@ -75,7 +75,7 @@ def test_with_delay(capsys):
         circuit.delay(100)
         circuit.cv_d(1, qmr[0])
 
-        state, result = c2qa.util.simulate(circuit)
+        state, result, _ = c2qa.util.simulate(circuit)
         assert result.success
 
 
@@ -122,7 +122,7 @@ def test_initialize_qubit_values(capsys):
             circuit = c2qa.CVCircuit(qmr)
             circuit.cv_initialize(fock, qmr[0])
 
-            state, result = c2qa.util.simulate(circuit)
+            state, result, _ = c2qa.util.simulate(circuit)
             assert result.success
 
             print(f"fock {fock} qubits {list(result.get_counts().keys())[0]}")

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -58,7 +58,7 @@ def assert_unchanged(state, result):
 
 def test_no_gates():
     circuit, qmr = create_unconditional()
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert_unchanged(state, result)
 
 
@@ -68,7 +68,7 @@ def test_beamsplitter_once():
     phi = random.random()
     circuit.cv_bs(phi, qmr[0], qmr[1])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
 
     # TODO - Beam splitter gate does not change state vector
     #        Both Strawberry Fields & FockWits are the same, too.
@@ -82,7 +82,7 @@ def test_conditional_beamsplitter():
     theta = random.random()
     circuit.cv_c_bs(theta, qmr[0], qmr[1], qr[0])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
 
     # TODO - Beam splitter gate does not change state vector
     #        Both Strawberry Fields & FockWits are the same, too.
@@ -99,7 +99,7 @@ def test_conditional_schwinger():
     phi_2 = random.random()
     circuit.cv_c_schwinger([beta, theta_1, phi_1, theta_2, phi_2], qmr[0], qmr[1], qr[0])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
 
     assert_unchanged(state, result)
 
@@ -111,7 +111,7 @@ def test_beamsplitter_twice():
     circuit.cv_bs(phi, qmr[0], qmr[1])
     circuit.cv_bs(-phi, qmr[0], qmr[1])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert_unchanged(state, result)
 
 
@@ -125,7 +125,7 @@ def test_conditonal_displacement():
     circuit.cv_c_d(-alpha, qmr[0], qr[1])
     circuit.cv_c_d(alpha, qmr[0], qr[1])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert_unchanged(state, result)
 
 
@@ -139,7 +139,7 @@ def test_conditonal_squeezing():
     circuit.cv_c_sq(-alpha, qmr[0], qr[1])
     circuit.cv_c_sq(alpha, qmr[0], qr[1])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert_unchanged(state, result)
 
 
@@ -151,7 +151,7 @@ def test_displacement_once(capsys):
         alpha = 1
         circuit.cv_d(alpha, qmr[0])
 
-        state, result = c2qa.util.simulate(circuit)
+        state, result, _ = c2qa.util.simulate(circuit)
         assert_changed(state, result)
 
 def test_cv_delay():
@@ -159,7 +159,7 @@ def test_cv_delay():
 
     circuit.cv_delay(100,qmr[0])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
 
 
 def test_displacement_twice():
@@ -169,7 +169,7 @@ def test_displacement_twice():
     circuit.cv_d(alpha, qmr[0])
     circuit.cv_d(-alpha, qmr[0])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert_unchanged(state, result)
 
 
@@ -185,7 +185,7 @@ def test_cond_displacement_gate_vs_two_separate():
     circuit = c2qa.CVCircuit(qmr, qr, cr)
     circuit.cv_initialize(0, qmr[0])  # qr[0] and cr[0] will init to zero
     circuit.cv_c_d(alpha, qmr[0], qr[0])
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert result.success
     state_cnd = result.get_statevector(circuit)
 
@@ -207,7 +207,7 @@ def test_cond_displacement_gate_vs_two_separate():
         ),
         [qr[0]] + qmr[0],
     )
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert result.success
     state_unitary = result.get_statevector(circuit)
 
@@ -234,7 +234,7 @@ def test_displacement_calibration(capsys):
         circuit.h(qr[0])
         circuit.measure(qr[0], cr[0])
 
-        state, result = c2qa.util.simulate(circuit)
+        state, result, _ = c2qa.util.simulate(circuit)
         assert result.success
 
         state = result.get_statevector(circuit)
@@ -255,7 +255,7 @@ def test_rotation_once():
     theta = random.random()
     circuit.cv_r(theta, qmr[0])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
 
     # TODO - Rotation gate does not change state vector.
     #        Both Strawberry Fields & FockWits are the same, too.
@@ -270,7 +270,7 @@ def test_rotation_twice():
     circuit.cv_r(theta, qmr[0])
     circuit.cv_r(-theta, qmr[0])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert_unchanged(state, result)
 
 
@@ -280,7 +280,7 @@ def test_squeezing_once():
     z = random.random()
     circuit.cv_sq(z, qmr[0])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert_changed(state, result)
 
 
@@ -291,7 +291,7 @@ def test_squeezing_twice():
     circuit.cv_sq(z, qmr[0])
     circuit.cv_sq(-z, qmr[0])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert_unchanged(state, result)
 
 
@@ -301,7 +301,7 @@ def test_two_mode_squeezing_once():
     z = random.random()
     circuit.cv_sq2(z, qmr[0], qmr[1])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert_changed(state, result)
 
 
@@ -312,7 +312,7 @@ def test_two_mode_squeezing_twice():
     circuit.cv_sq2(z, qmr[0], qmr[1])
     circuit.cv_sq2(-z, qmr[0], qmr[1])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
     assert_unchanged(state, result)
 
 
@@ -339,7 +339,7 @@ def test_gates():
     circuit.cv_c_sq(z, qmr[0], qr[0])
     circuit.cv_c_sq(z, qmr[1], qr[0])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
 
     assert result.success
 
@@ -351,7 +351,7 @@ def test_snap():
     n = 1
     circuit.cv_snap(phi, n, qmr[0])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
 
 
 def test_eswap():
@@ -360,7 +360,7 @@ def test_eswap():
     phi = random.random()
     circuit.cv_eswap(phi, qmr[0], qmr[1])
 
-    state, result = c2qa.util.simulate(circuit)
+    state, result, _ = c2qa.util.simulate(circuit)
 
 def test_multiboson_sampling(capsys):
     with capsys.disabled():
@@ -373,5 +373,5 @@ def test_multiboson_sampling(capsys):
         circuit = c2qa.CVCircuit(qmrA, qmrB, qbr)
         circuit.cv_c_multiboson_sampling([0,1,2,3], qmrA[0], qbr[0])
 
-        state, result = c2qa.util.simulate(circuit)
+        state, result, _ = c2qa.util.simulate(circuit)
         assert result.success

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -484,11 +484,11 @@ def test_photon_loss_instruction_qumode(capsys):
 
 def test_photon_loss_and_phase_damping(capsys):
     with capsys.disabled():
-        state_a, result_a = _build_photon_loss_and_amp_damping_circuit(0.0)
+        state_a, result_a, _ = _build_photon_loss_and_amp_damping_circuit(0.0)
         print(state_a)
         assert result_a.success
 
-        state_b, result_b = _build_photon_loss_and_amp_damping_circuit(1.0)
+        state_b, result_b, _ = _build_photon_loss_and_amp_damping_circuit(1.0)
         print(state_b)
         assert result_b.success
 
@@ -612,7 +612,7 @@ def test_multi_qumode_loss_probability(capsys):
         for i in range(20):
             print("----------------------")
             print(f"Iteration {i}")
-            state_vector, result = c2qa.util.simulate(circuit, noise_passes=noise_pass)
+            state_vector, result, _ = c2qa.util.simulate(circuit, noise_passes=noise_pass)
             # plot_histogram(result.get_counts(circuit), filename=f"tests/test_manual_validate_beamsplitter-{i}.png")
             occupation, fock_states = c2qa.util.stateread(state_vector, 0, num_qumodes, 2**num_qubits_per_qumode,verbose=True)
 

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -48,7 +48,7 @@ def test_noise_model(capsys):
         print("kraus")
         print(kraus_operators)
 
-        state, result = c2qa.util.simulate(circuit)
+        state, result, _ = c2qa.util.simulate(circuit)
 
 
 def test_kraus_operators(capsys):
@@ -200,7 +200,7 @@ def test_noise_with_beamsplitter(capsys):
         photon_loss_rate = 0.01
         time_unit = "ns"
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=init_circuit, time_unit=time_unit)
-        state, result = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
+        state, result, _ = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
 
 
 def test_noise_with_cnd_beamsplitter(capsys):
@@ -217,7 +217,7 @@ def test_noise_with_cnd_beamsplitter(capsys):
         photon_loss_rate = 0.01
         time_unit = "ns"
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=init_circuit, time_unit=time_unit)
-        state, result = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
+        state, result, _ = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
 
 
 def test_photon_loss_pass_with_conditional(capsys):
@@ -234,7 +234,7 @@ def test_photon_loss_pass_with_conditional(capsys):
         photon_loss_rate = 0.01
         time_unit = "ns"
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=init_circuit, time_unit=time_unit)
-        state, result = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
+        state, result, _ = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
 
 
 def test_photon_loss_pass_delay_without_unit(capsys):
@@ -253,7 +253,7 @@ def test_photon_loss_pass_delay_without_unit(capsys):
         photon_loss_rate = 0.01
         time_unit = "ns"
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=fail_circuit, time_unit=time_unit)
-        state, result = c2qa.util.simulate(fail_circuit, noise_passes=noise_pass)
+        state, result, _ = c2qa.util.simulate(fail_circuit, noise_passes=noise_pass)
         assert result.success
 
 
@@ -273,7 +273,7 @@ def test_photon_loss_pass_delay_with_unit(capsys):
         photon_loss_rate = 0.01
         time_unit = "ns"
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=pass_circuit, time_unit=time_unit)
-        state, result = c2qa.util.simulate(pass_circuit, noise_passes=noise_pass)
+        state, result, _ = c2qa.util.simulate(pass_circuit, noise_passes=noise_pass)
         assert result.success
 
 
@@ -343,7 +343,7 @@ def test_photon_loss_pass_no_displacement(capsys):
         time_unit = "ns"
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit)
 
-        # state, result = c2qa.util.simulate(circuit, noise_passes=noise_pass)
+        # state, result, _ = c2qa.util.simulate(circuit, noise_passes=noise_pass)
 
         wigner_filename = "tests/test_photon_loss_pass_no_displacement.mp4"
         c2qa.animate.animate_wigner(
@@ -370,7 +370,7 @@ def test_photon_loss_pass_slow_displacement(capsys):
         time_unit = "ns"
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit)
 
-        # state, result = c2qa.util.simulate(circuit, noise_passes=noise_pass)
+        # state, result, _ = c2qa.util.simulate(circuit, noise_passes=noise_pass)
 
         wigner_filename = "tests/test_photon_loss_pass_slow_displacement.mp4"
         c2qa.animate.animate_wigner(
@@ -401,7 +401,7 @@ def test_photon_loss_pass_slow_conditional_displacement(capsys):
         time_unit = "ns"
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit)
 
-        # state, result = c2qa.util.simulate(circuit, noise_passes=noise_pass)
+        # state, result, _ = c2qa.util.simulate(circuit, noise_passes=noise_pass)
 
         wigner_filename = "tests/test_photon_loss_pass_slow_conditional_displacement.mp4"
         c2qa.animate.animate_wigner(
@@ -432,7 +432,7 @@ def test_photon_loss_instruction(capsys):
         time_unit = "ns"
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit, instructions=["cD"])
 
-        state, result = c2qa.util.simulate(circuit, noise_passes=noise_pass)
+        state, result, _ = c2qa.util.simulate(circuit, noise_passes=noise_pass)
         assert result.success
 
 
@@ -455,7 +455,7 @@ def test_photon_loss_qumode(capsys):
         time_unit = "ns"
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit, qumodes=qmr[1])
 
-        state, result = c2qa.util.simulate(circuit, noise_passes=noise_pass)
+        state, result, _ = c2qa.util.simulate(circuit, noise_passes=noise_pass)
         assert result.success
 
 
@@ -478,7 +478,7 @@ def test_photon_loss_instruction_qumode(capsys):
         time_unit = "ns"
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit, instructions=["cD"], qumodes=qmr[0])
 
-        state, result = c2qa.util.simulate(circuit, noise_passes=noise_pass)
+        state, result, _ = c2qa.util.simulate(circuit, noise_passes=noise_pass)
         assert result.success
 
 

--- a/tests/test_parameterized.py
+++ b/tests/test_parameterized.py
@@ -48,7 +48,7 @@ def test_parameterized_displacement(capsys):
 
         bound_circuit = circuit.bind_parameters({alpha: 3.14})
 
-        state, result = c2qa.util.simulate(bound_circuit)
+        state, result, _ = c2qa.util.simulate(bound_circuit)
         assert_changed(state, result)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -196,7 +196,7 @@ def test_fockmap(capsys):
             assert(type(c2qa.util.fockmap(m_types[m_index], fi_types[fi_index], fo_types[fo_index], amp_types[amp_index])) == numpy.ndarray)
 
 
-def test_newcounts(capsys):
+def test_counts_to_fockcounts(capsys):
     with capsys.disabled():
         for i in range(5):
             # Generate 3 qmreg with random no. of qumodes each

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -14,7 +14,7 @@ def test_trace_out_zero(capsys):
         circuit.initialize([0, 1], qr[0])
         circuit.cv_initialize(0, qmr[0])
 
-        state, _ = c2qa.util.simulate(circuit)
+        state, _, _ = c2qa.util.simulate(circuit)
         trace = c2qa.util.trace_out_qubits(circuit, state)
 
         assert state.dims() == (2, 2, 2)
@@ -36,7 +36,7 @@ def test_trace_out_one(capsys):
         circuit.initialize([1, 0], qr[0])
         circuit.cv_initialize(1, qmr[0])
 
-        state, _ = c2qa.util.simulate(circuit)
+        state, _, _ = c2qa.util.simulate(circuit)
         trace = c2qa.util.trace_out_qubits(circuit, state)
 
         assert state.dims() == (2, 2, 2)
@@ -58,7 +58,7 @@ def test_trace_out_qubit(capsys):
         circuit.initialize([1, 0], qbr[0])
         circuit.cv_initialize(1, qmr[0])
 
-        state, _ = c2qa.util.simulate(circuit)
+        state, _, _ = c2qa.util.simulate(circuit)
         trace = c2qa.util.cv_partial_trace(circuit, state, qbr[0])
 
         assert state.dims() == (2, 2, 2)
@@ -80,7 +80,7 @@ def test_trace_out_qumode(capsys):
         circuit.initialize([1, 0], qbr[0])
         circuit.cv_initialize(1, qmr[0])
 
-        state, _ = c2qa.util.simulate(circuit)
+        state, _, _ = c2qa.util.simulate(circuit)
         trace = c2qa.util.cv_partial_trace(circuit, state, qmr[0])
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -138,7 +138,7 @@ def test_stateread(capsys):
 
         circuit.cv_initialize(2, qmr[0])
         circuit.cv_initialize(0, qmr[1])
-        state, result = c2qa.util.simulate(circuit)
+        state, result, _ = c2qa.util.simulate(circuit)
         c2qa.util.stateread(
             state,
             numberofqubits=0,
@@ -259,7 +259,7 @@ def test_newcounts(capsys):
                 # else:
                     regs.append(_regs[i])
 
-            # Compare output of fockcounts vs newcounts
+            # Compare output of cv_fockcounts vs counts_to_fockcounts
             _, result, counts = c2qa.util.simulate(circuit, return_fockcounts=True)
 #            print(result.get_counts(), c2qa.util._final_qumode_mapping(circuit))
             assert(counts == c2qa.util.cv_fockcounts(result.get_counts(), regs))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -146,3 +146,51 @@ def test_stateread(capsys):
             cutoff=circuit.cutoff,
             verbose=True,
         )
+
+def test_fockmap(capsys):
+    with capsys.disabled():
+
+        # Build rand array of rand dim between 1 and 100, use fockmap to populate initally empty array, and assert that final array is equal to rand array
+        for _ in range(10): # Repeat test 10 times
+            dim = numpy.random.randint(low=1, high = 101)
+            randarray = numpy.random.uniform(low=0, high=1, size=(dim, dim))
+
+            testmatrix = numpy.zeros((dim, dim))
+            for i in range(dim):
+                for j in range (dim):
+                    testmatrix = c2qa.util.fockmap(testmatrix, j, i, randarray[i, j])
+                     
+            assert((testmatrix == randarray).all())
+
+        # Check fockmap using numpy.outer
+        matrix = numpy.zeros((4, 4))
+        assert((c2qa.util.fockmap(matrix, 0, 0) == numpy.outer([1, 0, 0 ,0], [1, 0, 0, 0])).all()) # |0><0|
+        assert((c2qa.util.fockmap(matrix, 1, [3, 2], [1, 0.5]) == (numpy.outer([0, 0, 0 ,1], [0, 1, 0, 0]) + 0.5 * numpy.outer([0, 0, 1 ,0], [0, 1, 0, 0]))).all()) # |3><1| + 0.5|2><1|
+        assert((c2qa.util.fockmap(matrix, 1, [3, 2, 1]) == c2qa.util.fockmap(matrix, [1, 1, 1], [3, 2, 1])).all()) # |3><1| + |2><1| + |1><1|
+
+        # Check the types which are accepted for each arg.
+        for i in range(10):
+            # Nested list, numpy.ndarray
+            m_types = [[[0, 0],[0 ,0]], numpy.zeros((2, 2))] 
+
+            # int, list
+            fi_types = [0, [1, 0]]
+
+            # int, list
+            fo_types = [1, [1, 0]]
+
+            #int, float, complex, empty list, list, numpy.ndarray
+            amp_types = [1, 1.0, 1j, [], [1, 1], numpy.array([1, 1])]
+
+            # Generate random indices to test for
+            m_index = numpy.random.randint(0, 2)
+            fi_index = numpy.random.randint(0, 2)
+            fo_index = numpy.random.randint(0, 2)
+
+            if (fi_index == 0) & (fo_index == 0):
+                amp_index = numpy.random.randint(0, 4)
+            else:
+                amp_index = numpy.random.randint(3, 5)
+            
+            # Assert that output is a numpy.ndarray
+            assert(type(c2qa.util.fockmap(m_types[m_index], fi_types[fi_index], fo_types[fo_index], amp_types[amp_index])) == numpy.ndarray)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -100,9 +100,9 @@ def test_measure_all_xyz(capsys):
         circuit.cv_c_d(dist, qmr[0], qr[0])
 
         (
-            (state_x, result_x),
-            (state_y, result_y),
-            (state_z, result_z),
+            (state_x, result_x, _),
+            (state_y, result_y, _),
+            (state_z, result_z, _),
         ) = c2qa.util.measure_all_xyz(circuit)
 
         print("state_x.probabilities_dict()")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -260,6 +260,6 @@ def test_newcounts(capsys):
                     regs.append(_regs[i])
 
             # Compare output of fockcounts vs newcounts
-            _, result, counts = c2qa.util.simulate(circuit, counts=True)
+            _, result, counts = c2qa.util.simulate(circuit, return_fockcounts=True)
 #            print(result.get_counts(), c2qa.util._final_qumode_mapping(circuit))
             assert(counts == c2qa.util.cv_fockcounts(result.get_counts(), regs))

--- a/tests/test_wigner.py
+++ b/tests/test_wigner.py
@@ -21,7 +21,7 @@ def test_plot_zero(capsys):
         circuit.h(qr[0])
         circuit.cv_c_d(dist, qmr[0], qr[0])
 
-        state, _ = c2qa.util.simulate(circuit)
+        state, _, _ = c2qa.util.simulate(circuit)
         trace = c2qa.util.trace_out_qubits(circuit, state)
         c2qa.wigner.plot_wigner(circuit, trace, file="tests/zero.png", trace=False)
 
@@ -36,7 +36,7 @@ def test_plot_one(capsys):
         # qr[0] and cr[0] will init to zero
         circuit.cv_initialize(1, qmr[0])
 
-        state, _ = c2qa.util.simulate(circuit)
+        state, _, _ = c2qa.util.simulate(circuit)
         # print("Qumode initialized to one:")
         # print(state)
         c2qa.wigner.plot_wigner(circuit, state, file="tests/one.png")
@@ -81,7 +81,7 @@ def test_cat_state_wigner_plot(capsys):
         circuit.measure(qr[0], cr[0])
 
         # conditional_state_vector=True will return two state vectors, one for 0 and 1 classical register value
-        state, _ = c2qa.util.simulate(circuit, conditional_state_vector=True)
+        state, _, _ = c2qa.util.simulate(circuit, conditional_state_vector=True)
         even_state = state["0x0"]
         odd_state = state["0x1"]
 
@@ -138,7 +138,7 @@ def test_wigner_mle(capsys):
         circuit.cv_c_d(dist, qmr[0], qr[0])
         circuit.h(qr[0])
 
-        states, result = c2qa.util.simulate(circuit, per_shot_state_vector=True)
+        states, result, _ = c2qa.util.simulate(circuit, per_shot_state_vector=True)
         wigner = c2qa.wigner.wigner_mle(states)
         assert wigner is not None
         print(wigner)

--- a/tests/test_wigner.py
+++ b/tests/test_wigner.py
@@ -172,7 +172,7 @@ def test_plot_wigner_snapshot(capsys):
 
         circuit.cv_snapshot()
 
-        state, result = c2qa.util.simulate(circuit)
+        state, result, _ = c2qa.util.simulate(circuit)
 
         c2qa.wigner.plot_wigner_snapshot(circuit, result, "tests")
 


### PR DESCRIPTION
Hi Tim,

I'm not sure what the etiquette is for pull requests, but I figured it might be good to list the changes I've been working on. Here are a couple of new functions that Kevin told me would be good to add.

1. Added _util.fockmap()_ with unit test. Allows user to generate matrices by specifying arbitrary mappings between a set of input and output fock states. 
2. Added _operators.gate_from_matrix_. Used by _cv_gate_from_matrix_ when appending _ParameterizedUnitaryGate_
3. Added _circuit.cv_gate_from_matrix_ with unit test. Converts user specified unitary matrices to gates in the circuit. Meant to be used with _fockmap()_ to generate any arbitrary gate. 
4. Added _CVCircuit_ property _qumode_qubits_indices_grouped_. Same as _qumode_qubits_indices_, but it groups the qubits that belong to same qumodes together. Returns nested list.
5. Created _util.newcounts()_ with unit test. Meant as a replacement to _util.cv_fockcounts_. Instead of taking in (counts, qubit_qumode_list), _newcounts_ only needs needs (circuit, result) as its arguments and does the rest. _newcounts_ depends on the __final_qumode_mapping_ auxiliary function, and __final_measurement_mapping_ that I lifted from the _Mthree_ package.
6. Integrated _newcounts()_ into _simulate()_ as an argument named _return_fockcounts_