### PR TITLE
Average photon number function

### DIFF
--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 import qiskit
 import qiskit.quantum_info
-from qiskit.quantum_info import Statevector
+from qiskit.quantum_info import Statevector, DensityMatrix
 
 
 from c2qa import CVCircuit
@@ -725,3 +725,34 @@ def fockmap(matrix, fock_input, fock_output, amplitude=[]):
     
     else:
         raise ValueError("Please ensure that your args are correctly defined.")
+    
+
+def avg_photon_num(state, decimals: int=2):
+    """Return average photon number of state using the number operator.
+
+    Args:
+        state (Statevector or DensityMatrix): state to operate on
+        decimals: precision of calculation
+
+    Returns:
+        float: average photon number to specified precision
+    """
+    # Generate number operator based on dimension of state
+    dim = state.dim
+    N = np.diag(range(dim))
+    
+    # Normalise state
+    if isinstance(state, Statevector):
+        for_norm = state.inner(state)
+    elif isinstance(state, DensityMatrix):
+        for_norm = state.trace()  
+    else:
+        raise TypeError("Only Statevector or DensityMatrix are accepted as valid types.")
+    
+    # Calculate average photon number
+    avg_photon = state.expectation_value(N)/for_norm
+    
+    if round(avg_photon.imag, 6) != 0:
+        raise Exception("Magnitude of average photon is complex, check inputs. Imaginary portion = {}".format(avg_photon.imag))
+    
+    return np.round(avg_photon.real, decimals)

--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -728,15 +728,16 @@ def fockmap(matrix, fock_input, fock_output, amplitude=[]):
     
 
 def avg_photon_num(state, decimals: int=2):
-    """Return average photon number of state using the number operator.
+    """Returns average photon number of state using the number operator.
 
     Args:
-        state (Statevector or DensityMatrix): state to operate on
-        decimals: precision of calculation
+        state (Statevector or DensityMatrix): State to operate on
+        decimals: Determines precision of calculation
 
     Returns:
-        float: average photon number to specified precision
+        float: Average photon number to specified precision
     """
+    
     # Generate number operator based on dimension of state
     dim = state.dim
     N = np.diag(range(dim))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,6 +3,7 @@ import numpy
 from pathlib import Path
 import qiskit
 from qiskit.visualization import plot_histogram
+from qiskit.quantum_info import Statevector, DensityMatrix
 
 
 def test_trace_out_zero(capsys):
@@ -263,3 +264,26 @@ def test_counts_to_fockcounts(capsys):
             _, result, counts = c2qa.util.simulate(circuit, return_fockcounts=True)
 #            print(result.get_counts(), c2qa.util._final_qumode_mapping(circuit))
             assert(counts == c2qa.util.cv_fockcounts(result.get_counts(), regs))
+            
+            
+def test_avg_photon_num(capsys):
+    with capsys.disabled():
+        for _ in range(5): # Repeat test 5 times
+            # Decimals
+            decimals = numpy.random.randint(1, 6)
+            
+            # Generate random vector
+            dim = numpy.random.randint(1, 11)
+            vector = numpy.random.uniform(-1, 1, dim) + 1.j * numpy.random.uniform(-1, 1, dim)
+            
+            # Compute magnitude of each element within vector, and norm of vector
+            element_norm = numpy.multiply(vector, numpy.conjugate(vector))
+            norm = numpy.sum(element_norm)
+
+            # Dot product between number operator and magnitude
+            avg_num = numpy.mean(numpy.dot(element_norm, numpy.array(range(dim))))/norm
+            
+            # Average photon number of statevector, density matrix, and random vector must all match
+            assert(c2qa.util.avg_photon_num(Statevector(vector), decimals) == c2qa.util.avg_photon_num(DensityMatrix(vector), decimals) == round(avg_num.real, decimals))
+            
+            


### PR DESCRIPTION
Hi Tim and Kevin,

Just thought that adding a function specifically for computing average photon number for a given qumode state would be helpful for the repo. The docstring for the function is copied below. Let me know what you think!

```
def avg_photon_num(state, decimals: int=2):
    """Returns average photon number of state using the number operator.

    Args:
        state (Statevector or DensityMatrix): State to operate on
        decimals: Determines precision of calculation

    Returns:
        float: Average photon number to specified precision
    """
```