### PR TITLE
Update circuit.py

### DIFF
--- a/c2qa/circuit.py
+++ b/c2qa/circuit.py
@@ -3,7 +3,7 @@ import warnings
 
 import numpy as np
 from qiskit import QuantumCircuit, QuantumRegister
-from qiskit.circuit.parametertable import ParameterTable
+from qiskit.circuit.parametertable import ParameterView
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix
 import qiskit_aer.library.save_instructions as save
 


### PR DESCRIPTION
ParameterTable has depreciated as a class name since Qiskit v0.21, where it was changed to ParameterReferences. 
For Qiskit 1.2, it was again changed to ParameterView, which is my proposed change in circuit.py file.