### PR TITLE
removed references to ParameterTable

### DIFF
--- a/c2qa/__init__.py
+++ b/c2qa/__init__.py
@@ -1,4 +1,5 @@
 """Top-level package for bosonic-qiskit."""
+
 # flake8: noqa
 
 from c2qa.circuit import CVCircuit
@@ -11,4 +12,3 @@ import c2qa.operators
 import c2qa.parameterized_unitary_gate
 import c2qa.util
 import c2qa.wigner
-

--- a/c2qa/animate.py
+++ b/c2qa/animate.py
@@ -29,11 +29,11 @@ def animate_wigner(
     axes_steps: int = 200,
     processes: int = None,
     keep_state: bool = True,
-    noise_passes = None,
+    noise_passes=None,
     sequential_subcircuit: bool = False,
     draw_grid: bool = False,
     trace: bool = True,
-    bitrate: int = -1
+    bitrate: int = -1,
 ):
     """Animate the Wigner function at each step defined in the given CVCirctuit.
 
@@ -49,7 +49,7 @@ def animate_wigner(
         cbit ([type]): Classical bit to measure into, if performing Hadamard measure for use with cat states. Defaults to None.
         animation_segments (int, optional): Number of segments to split each gate into for animation. Defaults to 10.
         shots (int, optional): Number of simulation shots per frame. Defaults to 1.
-        file (str, optional): File path to save (supported formats include MP4 with ffmpeg installed, animated GIF, and APNG). 
+        file (str, optional): File path to save (supported formats include MP4 with ffmpeg installed, animated GIF, and APNG).
                               If None, return plot. Defaults to None.
         axes_min (int, optional): Minimum axes plot value. Defaults to -6.
         axes_max (int, optional): Maximum axes plot value. Defaults to 6.
@@ -60,7 +60,7 @@ def animate_wigner(
                                      False if each frame starts over from the beginning of the circuit.
                                      If True, it requires sequential simulation of each frame.
         noise_passes (list of Qiskit noise passes, optional): noise passes to apply
-        sequential_subcircuit (bool, optional): boolean flag to animate subcircuits as one gate (False) or as sequential 
+        sequential_subcircuit (bool, optional): boolean flag to animate subcircuits as one gate (False) or as sequential
                                                 gates (True). Defautls to False.
         draw_grid (bool, optional): True if grid lines should be drawn on plot. Defaults to False.
         trace (bool, optional):  True if qubits should be tracedfor each frame prior to calculating Wigner function. Defaults to True.
@@ -83,7 +83,7 @@ def animate_wigner(
             keep_state,
             noise_passes,
             sequential_subcircuit,
-            trace
+            trace,
         )
     else:
         w_fock, xvec = __discretize_wigner_without_measure(
@@ -96,7 +96,7 @@ def animate_wigner(
             axes_steps,
             noise_passes,
             sequential_subcircuit,
-            trace
+            trace,
         )
 
     # Remove None values in w_fock if simulation didn't produce results
@@ -135,11 +135,13 @@ def __discretize_wigner_with_measure(
     axes_steps: int = 200,
     processes: int = None,
     keep_state: bool = True,
-    noise_passes = None,
+    noise_passes=None,
     sequential_subcircuit: bool = False,
     trace: bool = True,
 ):
-    circuits = discretize_circuits(circuit, animation_segments, keep_state, qubit, cbit, sequential_subcircuit)
+    circuits = discretize_circuits(
+        circuit, animation_segments, keep_state, qubit, cbit, sequential_subcircuit
+    )
 
     # Calculate the Wigner functions for each frame
     if not processes or processes < 1:
@@ -150,7 +152,9 @@ def __discretize_wigner_with_measure(
     xvec = numpy.linspace(axes_min, axes_max, axes_steps)
 
     if keep_state:
-        w_fock = __simulate_wigner_with_state(circuits, qubit, cbit, xvec, shots, noise_passes, trace)
+        w_fock = __simulate_wigner_with_state(
+            circuits, qubit, cbit, xvec, shots, noise_passes, trace
+        )
     elif processes == 1:
         w_fock = []
         for circuit in circuits:
@@ -168,14 +172,22 @@ def __discretize_wigner_with_measure(
         results = pool.starmap(
             simulate_wigner,
             (
-                (circuit, xvec, shots, noise_passes, cbit is not None, trace or cbit is not None)
+                (
+                    circuit,
+                    xvec,
+                    shots,
+                    noise_passes,
+                    cbit is not None,
+                    trace or cbit is not None,
+                )
                 for circuit in circuits
             ),
         )
         pool.close()
         w_fock = [i[0] for i in results if i is not None]
-    
+
     return w_fock, xvec
+
 
 def __discretize_wigner_without_measure(
     circuit: CVCircuit,
@@ -185,20 +197,21 @@ def __discretize_wigner_without_measure(
     axes_min: int = -6,
     axes_max: int = 6,
     axes_steps: int = 200,
-    noise_passes = None,
+    noise_passes=None,
     sequential_subcircuit: bool = False,
     trace: bool = True,
 ):
     statevector_label = "segment_"
 
     discretized, num_statevectors = discretize_single_circuit(
-        circuit=circuit, 
+        circuit=circuit,
         segments_per_gate=animation_segments,
         epsilon=discretize_epsilon,
         sequential_subcircuit=sequential_subcircuit,
         statevector_per_segment=True,
         statevector_label=statevector_label,
-        noise_passes=noise_passes)
+        noise_passes=noise_passes,
+    )
 
     xvec = numpy.linspace(axes_min, axes_max, axes_steps)
 
@@ -209,7 +222,7 @@ def __discretize_wigner_without_measure(
         statevector_label=statevector_label,
         num_statevectors=num_statevectors,
         noise_passes=noise_passes,
-        trace=trace
+        trace=trace,
     )
 
     return w_fock, xvec
@@ -267,7 +280,14 @@ def _animate(frame, *fargs):
     if frame == 0:
         fig.colorbar(cont, ax=ax)
 
-    time_text = ax.text(0.05, 0.95, "", horizontalalignment="left", verticalalignment="top", transform=ax.transAxes)
+    time_text = ax.text(
+        0.05,
+        0.95,
+        "",
+        horizontalalignment="left",
+        verticalalignment="top",
+        transform=ax.transAxes,
+    )
     time_text.set_text(f"Frame {frame}")
 
     if file:
@@ -275,7 +295,9 @@ def _animate(frame, *fargs):
         plt.savefig(f"{file}_frames/frame_{frame}.png")
 
 
-def __simulate_wigner_with_state(circuits, qubit, cbit, xvec, shots, noise_passes, trace):
+def __simulate_wigner_with_state(
+    circuits, qubit, cbit, xvec, shots, noise_passes, trace
+):
     """Simulate Wigner function, preserving state between iterations"""
     w_fock = []
     previous_state = None

--- a/c2qa/discretize.py
+++ b/c2qa/discretize.py
@@ -7,12 +7,13 @@ from c2qa.parameterized_unitary_gate import ParameterizedUnitaryGate
 
 
 def discretize_circuits(
-        circuit: CVCircuit, 
-        segments_per_gate: int = 10, 
-        keep_state: bool = True, 
-        qubit:qiskit.circuit.quantumcircuit.QubitSpecifier = None, 
-        cbit: qiskit.circuit.quantumcircuit.QubitSpecifier = None, 
-        sequential_subcircuit: bool = False,):
+    circuit: CVCircuit,
+    segments_per_gate: int = 10,
+    keep_state: bool = True,
+    qubit: qiskit.circuit.quantumcircuit.QubitSpecifier = None,
+    cbit: qiskit.circuit.quantumcircuit.QubitSpecifier = None,
+    sequential_subcircuit: bool = False,
+):
     """
     Discretize gates into a circuit into segments where each segment ends an indiviudal circuit. Useful for incrementally applying noise or animating the circuit.
 
@@ -24,9 +25,9 @@ def discretize_circuits(
                                      If True, it requires sequential simulation of each segment.
         qubit ([QubitSpecifier]): Qubit to measure, if performing Hadamard measure for use with cat states. Defaults to None.
         cbit ([QubitSpecifier]): Classical bit to measure into, if performing Hadamard measure for use with cat states. Defaults to None.
-        sequential_subcircuit (bool, optional): boolean flag to animate subcircuits as one gate (False) or as sequential 
+        sequential_subcircuit (bool, optional): boolean flag to animate subcircuits as one gate (False) or as sequential
                                                 gates (True). Defautls to False.
-    
+
     Returns:
         [list]: List of discretized Qiskit circuit
     """
@@ -42,7 +43,9 @@ def discretize_circuits(
         # qubit = xxx
         # cbit = yyy
 
-        segments = __to_segments(inst, segments_per_gate, keep_state, sequential_subcircuit)
+        segments = __to_segments(
+            inst, segments_per_gate, keep_state, sequential_subcircuit
+        )
 
         for segment in segments:
             sim_circuit = base_circuit.copy()
@@ -58,19 +61,19 @@ def discretize_circuits(
 
             # Start with current circuit for the next segment
             base_circuit = sim_circuit
-    
+
     return sim_circuits
 
 
 def discretize_single_circuit(
-        circuit: CVCircuit, 
-        segments_per_gate: int = 10, 
-        epsilon: float = None,
-        sequential_subcircuit: bool = False,
-        statevector_per_segment: bool = False,
-        statevector_label: str = "segment_",
-        noise_passes = None
-    ):
+    circuit: CVCircuit,
+    segments_per_gate: int = 10,
+    epsilon: float = None,
+    sequential_subcircuit: bool = False,
+    statevector_per_segment: bool = False,
+    statevector_label: str = "segment_",
+    noise_passes=None,
+):
     """
     Discretize gates into a circuit into segments within a single output circuit. Useful for incrementally applying noise or animating the circuit.
 
@@ -79,14 +82,14 @@ def discretize_single_circuit(
         segments_per_gate (int, optional): Number of segments to split each gate into. Defaults to 10.
         epsilon (float, optional): float value used to discretize, must specify along with kappa
         kappa (float, optional): float phton loss rate to determine discretization sice, must specify along with epsilon
-        sequential_subcircuit (bool, optional): boolean flag to animate subcircuits as one gate (False) or as sequential 
+        sequential_subcircuit (bool, optional): boolean flag to animate subcircuits as one gate (False) or as sequential
                                                 gates (True). Defaults to False.
-        statevector_per_segment (bool, optional): boolean flag to save a statevector per gate segment. True will call Qiskit 
-                                                  save_statevector after each segment is simulated, creating statevectors labeled 
+        statevector_per_segment (bool, optional): boolean flag to save a statevector per gate segment. True will call Qiskit
+                                                  save_statevector after each segment is simulated, creating statevectors labeled
                                                   "segment_*" that can used after simulation. Defaults to False.
         statevector_label (str, optional): String prefix to use for the statevector saved after each segment
         noise_passes (list of Qiskit noise passes, optional): noise passes to apply
-    
+
     Returns:
         discretized Qiskit circuit
     """
@@ -102,33 +105,59 @@ def discretize_single_circuit(
     segment_count = 0
     for inst, qargs, cargs in circuit.data:
         num_segments = segments_per_gate
-        qargs_indices = [qubit._index for qubit in qargs]  # FIXME -- is there a public API to get the qubit's index in Qiskit v1.0+?
+        qargs_indices = [
+            qubit._index for qubit in qargs
+        ]  # FIXME -- is there a public API to get the qubit's index in Qiskit v1.0+?
 
-        if noise_passes and not (isinstance(inst, qiskit.circuit.instruction.Instruction) and inst.name == "initialize"):  # Don't discretize instructions initializing system state:
+        if noise_passes and not (
+            isinstance(inst, qiskit.circuit.instruction.Instruction)
+            and inst.name == "initialize"
+        ):  # Don't discretize instructions initializing system state:
             noise_pass = None
             for current in noise_passes:
-                if isinstance(current, PhotonLossNoisePass) and current.applies_to_instruction(inst, qargs_indices):
+                if isinstance(
+                    current, PhotonLossNoisePass
+                ) and current.applies_to_instruction(inst, qargs_indices):
                     noise_pass = current
                     break
-            
+
             if epsilon is not None and noise_pass is not None:
                 # FIXME - which of the qumodes' loss rates and QumodeRegister's cutoff should we use?
                 photon_loss_rate = noise_pass.photon_loss_rates_sec[0]
-                num_segments = math.ceil((photon_loss_rate * noise_pass.duration_to_sec(inst) * circuit.get_qmr_cutoff(0)) / epsilon)
+                num_segments = math.ceil(
+                    (
+                        photon_loss_rate
+                        * noise_pass.duration_to_sec(inst)
+                        * circuit.get_qmr_cutoff(0)
+                    )
+                    / epsilon
+                )
 
-        segments = __to_segments(inst=inst, segments_per_gate=num_segments, keep_state=True, sequential_subcircuit=sequential_subcircuit)
+        segments = __to_segments(
+            inst=inst,
+            segments_per_gate=num_segments,
+            keep_state=True,
+            sequential_subcircuit=sequential_subcircuit,
+        )
 
         for segment in segments:
             discretized.append(instruction=segment, qargs=qargs, cargs=cargs)
 
             if statevector_per_segment:
-                discretized.save_statevector(label=f"{statevector_label}{segment_count}")
+                discretized.save_statevector(
+                    label=f"{statevector_label}{segment_count}"
+                )
                 segment_count += 1
 
     return discretized, segment_count
 
 
-def __to_segments(inst: qiskit.circuit.instruction.Instruction, segments_per_gate: int, keep_state: bool, sequential_subcircuit: bool):
+def __to_segments(
+    inst: qiskit.circuit.instruction.Instruction,
+    segments_per_gate: int,
+    keep_state: bool,
+    sequential_subcircuit: bool,
+):
     """Split the instruction into segments_per_gate segments"""
 
     if isinstance(inst, ParameterizedUnitaryGate):
@@ -136,11 +165,23 @@ def __to_segments(inst: qiskit.circuit.instruction.Instruction, segments_per_gat
         segments = __discretize_parameterized(inst, segments_per_gate, keep_state)
 
     # FIXME -- how to identify a gate that was made with QuantumCircuit.to_gate()?
-    elif isinstance(inst.definition, qiskit.QuantumCircuit) and inst.name != "initialize" and inst.label != "cv_gate_from_matrix" and len(inst.decompositions) == 0:  # Don't animate subcircuits initializing system state
+    elif (
+        isinstance(inst.definition, qiskit.QuantumCircuit)
+        and inst.name != "initialize"
+        and inst.label != "cv_gate_from_matrix"
+        and len(inst.decompositions) == 0
+    ):  # Don't animate subcircuits initializing system state
         # print(f"Discretizing QuantumCircuit {inst.name}")
-        segments = __discretize_subcircuit(inst.definition, segments_per_gate, keep_state, sequential_subcircuit)
+        segments = __discretize_subcircuit(
+            inst.definition, segments_per_gate, keep_state, sequential_subcircuit
+        )
 
-    elif isinstance(inst, qiskit.circuit.instruction.Instruction) and inst.name != "initialize" and inst.label != "cv_gate_from_matrix" and len(inst.params) > 0:  # Don't animate instructions initializing system state
+    elif (
+        isinstance(inst, qiskit.circuit.instruction.Instruction)
+        and inst.name != "initialize"
+        and inst.label != "cv_gate_from_matrix"
+        and len(inst.params) > 0
+    ):  # Don't animate instructions initializing system state
         # print(f"Discretizing Instruction {inst.name}")
         segments = __discretize_instruction(inst, segments_per_gate, keep_state)
 
@@ -148,11 +189,16 @@ def __to_segments(inst: qiskit.circuit.instruction.Instruction, segments_per_gat
         # Else just "discretize" the instruction as a single segment
         # print(f"NOT discretizing {inst.name}")
         segments = [inst]
-    
+
     return segments
 
 
-def __discretize_parameterized(inst: qiskit.circuit.instruction.Instruction, segments_per_gate: int, keep_state: bool, discretized_param_indices: list = []):
+def __discretize_parameterized(
+    inst: qiskit.circuit.instruction.Instruction,
+    segments_per_gate: int,
+    keep_state: bool,
+    discretized_param_indices: list = [],
+):
     """Split ParameterizedUnitaryGate into multiple segments"""
     segments = []
     for index in range(1, segments_per_gate + 1):
@@ -184,14 +230,27 @@ def __discretize_parameterized(inst: qiskit.circuit.instruction.Instruction, seg
     return segments
 
 
-def __discretize_subcircuit(subcircuit: qiskit.QuantumCircuit, segments_per_gate: int, keep_state: bool, sequential_subcircuit: bool):
+def __discretize_subcircuit(
+    subcircuit: qiskit.QuantumCircuit,
+    segments_per_gate: int,
+    keep_state: bool,
+    sequential_subcircuit: bool,
+):
     """Create a list of circuits where the entire subcircuit is converted into segments (vs a single instruction)."""
 
     segments = []
     sub_segments = []
 
     for inst, qargs, cargs in subcircuit.data:
-        sub_segments.append((__to_segments(inst, segments_per_gate, keep_state, sequential_subcircuit), qargs, cargs))
+        sub_segments.append(
+            (
+                __to_segments(
+                    inst, segments_per_gate, keep_state, sequential_subcircuit
+                ),
+                qargs,
+                cargs,
+            )
+        )
 
     if sequential_subcircuit:
         # Sequentially animate each gate within the subcircuit
@@ -202,7 +261,7 @@ def __discretize_subcircuit(subcircuit: qiskit.QuantumCircuit, segments_per_gate
             gates, gate_qargs, gate_cargs = sub_segment
             for gate in gates:
                 subcircuit_copy.append(gate, gate_qargs, gate_cargs)
-        
+
         segments.append(subcircuit)
     else:
         # Animate the subcircuit as one gate
@@ -210,15 +269,19 @@ def __discretize_subcircuit(subcircuit: qiskit.QuantumCircuit, segments_per_gate
             subcircuit_copy = subcircuit.copy()
             subcircuit_copy.data.clear()  # Is this safe -- could we copy without data?
 
-            for sub_segment,  qargs, cargs in sub_segments:
+            for sub_segment, qargs, cargs in sub_segments:
                 subcircuit_copy.append(sub_segment[segment], qargs, cargs)
-            
+
             segments.append(subcircuit_copy)
 
-    return segments    
+    return segments
 
 
-def __discretize_instruction(inst: qiskit.circuit.instruction.Instruction, segments_per_gate: int, keep_state: bool):
+def __discretize_instruction(
+    inst: qiskit.circuit.instruction.Instruction,
+    segments_per_gate: int,
+    keep_state: bool,
+):
     """Split Qiskit Instruction into multiple segments"""
     segments = []
 
@@ -233,12 +296,12 @@ def __discretize_instruction(inst: qiskit.circuit.instruction.Instruction, segme
             total_steps=segments_per_gate,
             keep_state=keep_state,
         )
-        
+
         segments.append(
             qiskit.circuit.instruction.Instruction(
                 name=inst.name,
                 num_qubits=inst.num_qubits,
-                num_clbits = inst.num_clbits,
+                num_clbits=inst.num_clbits,
                 params=params,
                 duration=duration,
                 unit=unit,

--- a/c2qa/operators.py
+++ b/c2qa/operators.py
@@ -23,14 +23,14 @@ class CVOperators:
         ).tocsc()
 
     def get_a1(self, cutoff_a: int, cutoff_b: int):
-            return scipy.sparse.kron(self.get_a(cutoff_a), self.get_eye(cutoff_b)).tocsc()
-    
+        return scipy.sparse.kron(self.get_a(cutoff_a), self.get_eye(cutoff_b)).tocsc()
+
     def get_a2(self, cutoff_a: int, cutoff_b: int):
         return scipy.sparse.kron(self.get_eye(cutoff_a), self.get_a(cutoff_b)).tocsc()
-        
+
     def get_a12(self, cutoff_a: int, cutoff_b: int):
         return self.get_a1(cutoff_a, cutoff_b) * self.get_a2(cutoff_a, cutoff_b)
-    
+
     def get_a_dag(self, cutoff: int):
         """Creation operator"""
         a = self.get_a(cutoff)
@@ -41,19 +41,19 @@ class CVOperators:
         a = self.get_a(cutoff)
         a_dag = self.get_a_dag(cutoff)
         return a_dag * a
-    
+
     def get_a1_dag(self, cutoff_a: int, cutoff_b: int):
         return self.get_a1(cutoff_a, cutoff_b).conjugate().transpose().tocsc()
-    
+
     def get_a2_dag(self, cutoff_a: int, cutoff_b: int):
         return self.get_a2(cutoff_a, cutoff_b).conjugate().transpose().tocsc()
-    
+
     def get_a12_dag(self, cutoff_a: int, cutoff_b: int):
         return self.get_a1_dag(cutoff_a, cutoff_b) * self.get_a2_dag(cutoff_a, cutoff_b)
-    
+
     def get_a12dag(self, cutoff_a: int, cutoff_b: int):
         return self.get_a1(cutoff_a, cutoff_b) * self.get_a2_dag(cutoff_a, cutoff_b)
-    
+
     def get_a1dag2(self, cutoff_a: int, cutoff_b: int):
         return self.get_a1_dag(cutoff_a, cutoff_b) * self.get_a2(cutoff_a, cutoff_b)
 
@@ -83,7 +83,9 @@ class CVOperators:
         Returns:
             csc_matrix: operator matrix
         """
-        arg = (alpha * self.get_a_dag(cutoff)) - (numpy.conjugate(alpha) * self.get_a(cutoff))
+        arg = (alpha * self.get_a_dag(cutoff)) - (
+            numpy.conjugate(alpha) * self.get_a(cutoff)
+        )
 
         return scipy.sparse.linalg.expm(arg)
 
@@ -114,7 +116,9 @@ class CVOperators:
             csc_matrix: operator matrix
         """
 
-        arg = (numpy.conjugate(theta * 1j) * self.get_a12_dag(cutoff_a, cutoff_b)) - (theta * 1j * self.get_a12(cutoff_a, cutoff_b))
+        arg = (numpy.conjugate(theta * 1j) * self.get_a12_dag(cutoff_a, cutoff_b)) - (
+            theta * 1j * self.get_a12(cutoff_a, cutoff_b)
+        )
 
         return scipy.sparse.linalg.expm(arg)
 
@@ -128,7 +132,9 @@ class CVOperators:
             csc_matrix: operator matrix
         """
 
-        arg = theta * self.get_a1dag2(cutoff_a, cutoff_b) - numpy.conj(theta) * self.get_a12dag(cutoff_a, cutoff_b)
+        arg = theta * self.get_a1dag2(cutoff_a, cutoff_b) - numpy.conj(
+            theta
+        ) * self.get_a12dag(cutoff_a, cutoff_b)
 
         return scipy.sparse.linalg.expm(arg)
 
@@ -181,10 +187,14 @@ class CVOperators:
         Returns:
             bsr_matrix: operator matrix
         """
-        displace0 = (theta * self.get_a_dag(cutoff)) - (numpy.conjugate(theta) * self.get_a(cutoff))
+        displace0 = (theta * self.get_a_dag(cutoff)) - (
+            numpy.conjugate(theta) * self.get_a(cutoff)
+        )
         if beta is None:
             beta = -theta
-        displace1 = (beta * self.get_a_dag(cutoff)) - (numpy.conjugate(beta) * self.get_a(cutoff))
+        displace1 = (beta * self.get_a_dag(cutoff)) - (
+            numpy.conjugate(beta) * self.get_a(cutoff)
+        )
 
         return scipy.sparse.kron(
             (idQB + zQB) / 2, scipy.sparse.linalg.expm(displace0)
@@ -199,7 +209,9 @@ class CVOperators:
         Returns:
             csr_matrix: operator matrix
         """
-        argm = (theta * self.get_a_dag(cutoff)) - (numpy.conjugate(theta) * self.get_a(cutoff))
+        argm = (theta * self.get_a_dag(cutoff)) - (
+            numpy.conjugate(theta) * self.get_a(cutoff)
+        )
         arg = scipy.sparse.kron(zQB, argm)
 
         return scipy.sparse.linalg.expm(arg)
@@ -213,8 +225,10 @@ class CVOperators:
         Returns:
             csc_matrix: operator matrix
         """
-        
-        argm = theta * self.get_a1dag2(cutoff_a, cutoff_b) - numpy.conjugate(theta) * self.get_a12dag(cutoff_a, cutoff_b)
+
+        argm = theta * self.get_a1dag2(cutoff_a, cutoff_b) - numpy.conjugate(
+            theta
+        ) * self.get_a12dag(cutoff_a, cutoff_b)
         arg = scipy.sparse.kron(zQB, argm).tocsc()
 
         return scipy.sparse.linalg.expm(arg)
@@ -229,15 +243,32 @@ class CVOperators:
             csc_matrix: operator matrix
         """
 
-        Sx = (self.get_a1(cutoff_a, cutoff_b) * self.get_a2_dag(cutoff_a, cutoff_b) + self.get_a1_dag(cutoff_a, cutoff_b) * self.get_a2(cutoff_a, cutoff_b))/2
-        Sy = (self.get_a1(cutoff_a, cutoff_b) * self.get_a2_dag(cutoff_a, cutoff_b) - self.get_a1_dag(cutoff_a, cutoff_b) * self.get_a2(cutoff_a, cutoff_b))/(2*1j)
-        Sz = (self.get_a2_dag(cutoff_a, cutoff_b) * self.get_a2(cutoff_a, cutoff_b) - self.get_a1_dag(cutoff_a, cutoff_b) * self.get_a1(cutoff_a, cutoff_b))/2
+        Sx = (
+            self.get_a1(cutoff_a, cutoff_b) * self.get_a2_dag(cutoff_a, cutoff_b)
+            + self.get_a1_dag(cutoff_a, cutoff_b) * self.get_a2(cutoff_a, cutoff_b)
+        ) / 2
+        Sy = (
+            self.get_a1(cutoff_a, cutoff_b) * self.get_a2_dag(cutoff_a, cutoff_b)
+            - self.get_a1_dag(cutoff_a, cutoff_b) * self.get_a2(cutoff_a, cutoff_b)
+        ) / (2 * 1j)
+        Sz = (
+            self.get_a2_dag(cutoff_a, cutoff_b) * self.get_a2(cutoff_a, cutoff_b)
+            - self.get_a1_dag(cutoff_a, cutoff_b) * self.get_a1(cutoff_a, cutoff_b)
+        ) / 2
 
-        sigma = numpy.sin(theta_1)*numpy.cos(phi_1)*xQB + numpy.sin(theta_1)*numpy.sin(phi_1)*yQB + numpy.cos(theta_1)*zQB
-        S = numpy.sin(theta_2)*numpy.cos(phi_2)*Sx + numpy.sin(theta_2)*numpy.sin(phi_2)*Sy + numpy.cos(theta_2)*Sz
+        sigma = (
+            numpy.sin(theta_1) * numpy.cos(phi_1) * xQB
+            + numpy.sin(theta_1) * numpy.sin(phi_1) * yQB
+            + numpy.cos(theta_1) * zQB
+        )
+        S = (
+            numpy.sin(theta_2) * numpy.cos(phi_2) * Sx
+            + numpy.sin(theta_2) * numpy.sin(phi_2) * Sy
+            + numpy.cos(theta_2) * Sz
+        )
         arg = scipy.sparse.kron(sigma, S).tocsc()
 
-        return scipy.sparse.linalg.expm(-1j*beta*arg)
+        return scipy.sparse.linalg.expm(-1j * beta * arg)
 
     def snap(self, theta, n, cutoff):
         """SNAP (Selective Number-dependent Arbitrary Phase) operator
@@ -276,23 +307,23 @@ class CVOperators:
         # sparse_projector = scipy.sparse.csc_matrix(projector)
         arg = theta * 1j * scipy.sparse.kron(zQB, projector).tocsc()
         return scipy.sparse.linalg.expm(arg)
-        
+
     def multisnap(self, *args):
         """SNAP (Selective Number-dependent Arbitrary Phase) operator for multiple Fock states.
         Generates an arbitrary number of fock-number selective qubit rotations.
-        
+
         Args:
             args (List[reals, integers]): [List of phases, List of Fock states in which the mode should acquire the associated phase]
-        
+
         Returns:
             csr_matrix: operator matrix
         """
         # Divide list in two because thetas and ns must be sent in as a single list
         cutoff = args[-1]
         theta_ns = args[0:-1]
-        thetas = theta_ns[:len(theta_ns) // 2] # arguments
-        ns = theta_ns[len(theta_ns) // 2:] # Fock states on which they are applied
-        if len(thetas)!=len(ns): # one theta per Fock state to apply it to
+        thetas = theta_ns[: len(theta_ns) // 2]  # arguments
+        ns = theta_ns[len(theta_ns) // 2 :]  # Fock states on which they are applied
+        if len(thetas) != len(ns):  # one theta per Fock state to apply it to
             raise Exception("len(theta) must be equal to len(n)")
 
         id = numpy.eye(cutoff)
@@ -309,39 +340,38 @@ class CVOperators:
     def multicsnap(self, *args):
         """SNAP (Selective Number-dependent Arbitrary Phase) operator for multiple Fock states.
         Generates an arbitrary number of fock-number selective qubit rotations, with the qubit that accrues the geometric phase explicit.
-        
+
         Args:
             args (List[reals, integers]): [List of phases, List of Fock states in which the mode should acquire the associated phase]
-        
+
         Returns:
             csr_matrix: operator matrix
         """
         # Divide list in two because thetas and ns must be sent in as a single list
         cutoff = args[-1]
         theta_ns = args[0:-1]
-        thetas = theta_ns[:len(theta_ns) // 2] # arguments
-        ns = theta_ns[len(theta_ns) // 2:] # Fock states on which they are applied
-        if len(thetas)!=len(ns): # one theta per Fock state to apply it to
+        thetas = theta_ns[: len(theta_ns) // 2]  # arguments
+        ns = theta_ns[len(theta_ns) // 2 :]  # Fock states on which they are applied
+        if len(thetas) != len(ns):  # one theta per Fock state to apply it to
             raise Exception("len(theta) must be equal to len(n)")
 
         id = numpy.eye(cutoff)
-        gate = scipy.sparse.csr_matrix(scipy.sparse.kron(idQB,id))
+        gate = scipy.sparse.csr_matrix(scipy.sparse.kron(idQB, id))
         for i in range(len(ns)):
             ket_n = numpy.zeros(cutoff)
             ket_n[ns[i]] = 1
             projector = numpy.outer(ket_n, ket_n)
             coeff = scipy.sparse.linalg.expm(1j * thetas[i] * zQB) - idQB
-            mat = scipy.sparse.kron(coeff,projector).tocsr()
+            mat = scipy.sparse.kron(coeff, projector).tocsr()
             gate = numpy.add(gate, mat)
         return scipy.sparse.csr_matrix(gate)
 
-    
     def pnr(self, max, cutoff):
         """Support gate for photon number readout (see Curtis et al., PRA (2021) and Wang et al., PRX (2020))
-        
+
         Args:
             max (int): the period of the mapping
-        
+
         Returns:
             csc_matrix: operator matrix
         """
@@ -352,11 +382,11 @@ class CVOperators:
             for i in range(j, cutoff, max):
                 ket_n = numpy.zeros(cutoff)
                 # fill from right to left
-                ket_n[-(i+1)] = 1
+                ket_n[-(i + 1)] = 1
                 projector += numpy.outer(ket_n, ket_n)
 
         # Flip qubit if there is a boson present in any of the modes addressed by the projector
-        arg = 1j * (-numpy.pi/2) * scipy.sparse.kron(xQB, projector).tocsc()
+        arg = 1j * (-numpy.pi / 2) * scipy.sparse.kron(xQB, projector).tocsc()
         return scipy.sparse.linalg.expm(arg)
 
     def eswap(self, theta, cutoff_a, cutoff_b):
@@ -379,7 +409,6 @@ class CVOperators:
 
         return scipy.sparse.linalg.expm(arg)
 
-
     def csq(self, theta, cutoff):
         """Single-mode squeezing operator
 
@@ -391,10 +420,11 @@ class CVOperators:
         """
         a_sqr = self.get_a(cutoff) * self.get_a(cutoff)
         a_dag_sqr = self.get_a_dag(cutoff) * self.get_a_dag(cutoff)
-        arg = scipy.sparse.kron(zQB, 0.5 * ((numpy.conjugate(theta) * a_sqr) - (theta * a_dag_sqr))).tocsc()
+        arg = scipy.sparse.kron(
+            zQB, 0.5 * ((numpy.conjugate(theta) * a_sqr) - (theta * a_dag_sqr))
+        ).tocsc()
 
         return scipy.sparse.linalg.expm(arg)
-
 
     def testqubitorderf(self, phi):
 
@@ -403,10 +433,10 @@ class CVOperators:
 
     def c_multiboson_sampling(self, max, cutoff):
         """SNAP gate creation for multiboson sampling purposes.
-        
+
         Args:
             max (int): the period of the mapping
-        
+
         Returns:
             dia_matrix: operator matrix
         """
@@ -419,8 +449,8 @@ class CVOperators:
 
         Args:
             matrix (list): the (unitary) matrix that you wish to convert into a gate
-            
+
         Returns:
             csc_matrix: operator matrix
-        """ 
+        """
         return scipy.sparse.csc_matrix(matrix)

--- a/c2qa/parameterized_unitary_gate.py
+++ b/c2qa/parameterized_unitary_gate.py
@@ -12,7 +12,15 @@ class ParameterizedUnitaryGate(Gate):
     """UnitaryGate sublcass that stores the operator matrix for later reference by animation utility."""
 
     def __init__(
-        self, op_func, params, num_qubits, cutoffs, label=None, duration=100, unit="ns", discretized_param_indices: list = []
+        self,
+        op_func,
+        params,
+        num_qubits,
+        cutoffs,
+        label=None,
+        duration=100,
+        unit="ns",
+        discretized_param_indices: list = [],
     ):
         """Initialize ParameterizedUnitaryGate
 
@@ -56,7 +64,7 @@ class ParameterizedUnitaryGate(Gate):
                 )  # just cast everything to complex to avoid errors in Ubuntu/MacOS vs Windows
             else:
                 values.append(param)
-        
+
         # Add cutoff for each parameter
         values.extend(self.cutoffs)
 
@@ -103,7 +111,7 @@ class ParameterizedUnitaryGate(Gate):
         Args:
             current_step (int, optional): Current step within total_steps. Defaults to 1.
             total_steps (int, optional): Total steps to increment parameters. Defaults to 1.
-            
+
         Returns:
             ndarray: operator matrix
         """
@@ -131,12 +139,12 @@ def __calculate_segment_params(
 ):
     """
     Calculate the parameters at the current step. Return a tuples of the values.
-    
+
      Args:
         current_step (int): 0-based current step index of the discretization
         total_steps (int): total number of discretization steps
         keep_state (bool): true if the state should be kept between discretization steps (i.e., if the discretization value should be 1/total_steps vs current_step/total_steps)
-        
+
     Returns:
         discretized parameter values as tuple
     """
@@ -147,7 +155,11 @@ def __calculate_segment_params(
 
     values = []
     for index, param in enumerate(self.params):
-        if not hasattr(self, "discretized_param_indices") or len(self.discretized_param_indices) == 0 or index in self.discretized_param_indices:
+        if (
+            not hasattr(self, "discretized_param_indices")
+            or len(self.discretized_param_indices) == 0
+            or index in self.discretized_param_indices
+        ):
             values.append(param * param_fraction)
         else:
             values.append(param)
@@ -168,10 +180,14 @@ def __calculate_segment_duration(
             fraction = current_step / total_steps
 
         frame_duration = self.duration * fraction
-    
+
     return frame_duration, self.unit
 
 
 # Monkey patch Qiskit Instruction to support animating base Qiskit Instruction
-qiskit.circuit.instruction.Instruction.calculate_segment_params = __calculate_segment_params
-qiskit.circuit.instruction.Instruction.calculate_segment_duration = __calculate_segment_duration
+qiskit.circuit.instruction.Instruction.calculate_segment_params = (
+    __calculate_segment_params
+)
+qiskit.circuit.instruction.Instruction.calculate_segment_duration = (
+    __calculate_segment_duration
+)

--- a/c2qa/qumoderegister.py
+++ b/c2qa/qumoderegister.py
@@ -76,7 +76,7 @@ class QumodeRegister:
     def __len__(self):
         """The length of a QumodeRegister is the number of qumodes (not the num_qumodes * num_qubits_per_qumode)"""
         return self.num_qumodes
-    
+
     def __contains__(self, qubit):
         """Return true if this QumodeRegister contains the given qubit. This allows callers to use `in` python syntax."""
         return qubit in self.qreg

--- a/c2qa/wigner.py
+++ b/c2qa/wigner.py
@@ -20,18 +20,18 @@ def simulate_wigner(
     circuit: CVCircuit,
     xvec: np.ndarray,
     shots: int,
-    noise_passes = None,
+    noise_passes=None,
     conditional: bool = True,
     trace: bool = False,
-    g = sqrt(2),
-    method: str = "clenshaw"
+    g=sqrt(2),
+    method: str = "clenshaw",
 ):
     """Simulate the circuit, optionally partial trace the results, and calculate the Wigner function."""
     states, _, _ = simulate(
         circuit,
         shots=shots,
         noise_passes=noise_passes,
-        conditional_state_vector=conditional
+        conditional_state_vector=conditional,
     )
 
     if states:
@@ -62,18 +62,14 @@ def simulate_wigner_multiple_statevectors(
     xvec: np.ndarray,
     shots: int,
     statevector_label: str,
-    num_statevectors:int,
+    num_statevectors: int,
     noise_passes=None,
     trace: bool = False,
-    g = sqrt(2),
-    method: str = "clenshaw"
+    g=sqrt(2),
+    method: str = "clenshaw",
 ):
     """Simulate the circuit, optionally partial trace the results, and calculate the Wigner function on each statevector starting with the given label."""
-    state, result, _ = simulate(
-        circuit,
-        shots=shots,
-        noise_passes=noise_passes
-    )
+    state, result, _ = simulate(circuit, shots=shots, noise_passes=noise_passes)
 
     if len(result.results):
         wigner_results = []
@@ -93,13 +89,14 @@ def simulate_wigner_multiple_statevectors(
 
     return wigner_results
 
+
 def wigner(
     state,
     axes_min: int = -6,
     axes_max: int = 6,
     axes_steps: int = 200,
-    g = sqrt(2),
-    method: str = "clenshaw"
+    g=sqrt(2),
+    method: str = "clenshaw",
 ):
     """
     Calculate the Wigner function on the given state vector.
@@ -124,8 +121,8 @@ def wigner_mle(
     axes_min: int = -6,
     axes_max: int = 6,
     axes_steps: int = 200,
-    g = sqrt(2),
-    method: str ="clenshaw"
+    g=sqrt(2),
+    method: str = "clenshaw",
 ):
     """
     Find the maximum likelihood estimation for the given state vectors and calculate the Wigner function on the result.
@@ -157,7 +154,7 @@ def wigner_mle(
     return wigner(mle_normalized, axes_min, axes_max, axes_steps, g=g, method=method)
 
 
-def _wigner(state, xvec, yvec = None, g = sqrt(2), method: str = "clenshaw"):
+def _wigner(state, xvec, yvec=None, g=sqrt(2), method: str = "clenshaw"):
     if isinstance(state, DensityMatrix):
         rho = state.data
     else:
@@ -180,8 +177,8 @@ def plot_wigner(
     num_colors: int = 100,
     draw_grid: bool = False,
     dpi: int = 100,
-    g = sqrt(2),
-    method: str = "clenshaw"
+    g=sqrt(2),
+    method: str = "clenshaw",
 ):
     """Produce a Matplotlib figure for the Wigner function on the given state vector.
 
@@ -205,11 +202,11 @@ def plot_wigner(
 
     w_fock = wigner(
         state=state,
-        axes_min=axes_min, 
+        axes_min=axes_min,
         axes_max=axes_max,
         axes_steps=axes_steps,
         g=g,
-        method=method
+        method=method,
     )
 
     plot(
@@ -220,7 +217,7 @@ def plot_wigner(
         file=file,
         num_colors=num_colors,
         draw_grid=draw_grid,
-        dpi = dpi
+        dpi=dpi,
     )
 
 
@@ -232,7 +229,7 @@ def plot(
     file: str = None,
     num_colors: int = 100,
     draw_grid: bool = False,
-    dpi = 100
+    dpi=100,
 ):
     """Contour plot the given data array"""
     xvec = np.linspace(axes_min, axes_max, axes_steps)
@@ -254,13 +251,12 @@ def plot(
     # ax.set_xticks(xvec_int)
     ax.set_ylabel(r"$p$")
     # ax.set_yticks(xvec_int)
-    ax.set_aspect('equal', 'box')
+    ax.set_aspect("equal", "box")
     if draw_grid:
         ax.grid()
 
-
-    cb = fig.colorbar(cont, ax=ax, format=tick.FormatStrFormatter('%.2f'))
-    cb.set_label(r"$W(x,p)$",rotation=270,labelpad=25)
+    cb = fig.colorbar(cont, ax=ax, format=tick.FormatStrFormatter("%.2f"))
+    cb.set_label(r"$W(x,p)$", rotation=270, labelpad=25)
 
     if file:
         plt.savefig(file, dpi=dpi)
@@ -268,7 +264,14 @@ def plot(
         plt.show()
 
 
-def plot_wigner_projection(circuit: CVCircuit, qubit, file: str = None, draw_grid: bool = False, g = sqrt(2), method: str = "clenshaw"):
+def plot_wigner_projection(
+    circuit: CVCircuit,
+    qubit,
+    file: str = None,
+    draw_grid: bool = False,
+    g=sqrt(2),
+    method: str = "clenshaw",
+):
     """Plot the projection onto 0, 1, +, - for the given circuit.
 
     This is limited to CVCircuit with only one qubit, also provided as a parameter.
@@ -338,7 +341,9 @@ def plot_wigner_projection(circuit: CVCircuit, qubit, file: str = None, draw_gri
     _add_contourf(ax0, fig, "Projection onto zero", xvec, xvec, wigner_zero, draw_grid)
     _add_contourf(ax1, fig, "Projection onto one", xvec, xvec, wigner_one, draw_grid)
     _add_contourf(ax2, fig, "Projection onto plus", xvec, xvec, wigner_plus, draw_grid)
-    _add_contourf(ax3, fig, "Projection onto minus", xvec, xvec, wigner_minus, draw_grid)
+    _add_contourf(
+        ax3, fig, "Projection onto minus", xvec, xvec, wigner_minus, draw_grid
+    )
 
     # Save to file or display
     if file:
@@ -349,15 +354,15 @@ def plot_wigner_projection(circuit: CVCircuit, qubit, file: str = None, draw_gri
 
 def plot_wigner_snapshot(
     circuit: CVCircuit,
-    result: Result, 
+    result: Result,
     folder: Path = None,
     trace: bool = True,
     axes_min: int = -6,
     axes_max: int = 6,
     axes_steps: int = 200,
     num_colors: int = 100,
-    g = sqrt(2),
-    method: str = "clenshaw"
+    g=sqrt(2),
+    method: str = "clenshaw",
 ):
     for cv_snapshot_id in range(circuit.cv_snapshot_id):
         label = f"cv_snapshot_{cv_snapshot_id}"
@@ -366,7 +371,7 @@ def plot_wigner_snapshot(
             file = Path(folder, f"{label}.png")
         else:
             file = f"{label}.png"
-        
+
         snapshot = result.data()[label]
         # index = 0
         # if len(snapshot) > 1:
@@ -374,7 +379,18 @@ def plot_wigner_snapshot(
         #     index = len(snapshot) - 1
 
         # plot_wigner(circuit, snapshot[index], trace, file, axes_min, axes_max, axes_steps, num_colors, g=g, method=method)
-        plot_wigner(circuit, snapshot, trace, file, axes_min, axes_max, axes_steps, num_colors, g=g, method=method)
+        plot_wigner(
+            circuit,
+            snapshot,
+            trace,
+            file,
+            axes_min,
+            axes_max,
+            axes_steps,
+            num_colors,
+            g=g,
+            method=method,
+        )
 
 
 def _add_contourf(ax, fig, title, x, y, z, draw_grid: bool = False):

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -22,25 +22,27 @@ def __build_subcircuit():
     alpha = 1
 
     # Choose total animation time
-    total_time = 1*2*numpy.pi/omega_R
+    total_time = 1 * 2 * numpy.pi / omega_R
 
     # Create new circuit
-    qmr = c2qa.QumodeRegister(num_qumodes=1, num_qubits_per_qumode=num_qubits_per_qumode)
+    qmr = c2qa.QumodeRegister(
+        num_qumodes=1, num_qubits_per_qumode=num_qubits_per_qumode
+    )
     qbr = qiskit.QuantumRegister(1)
-    U_JC = c2qa.CVCircuit(qmr,qbr)
+    U_JC = c2qa.CVCircuit(qmr, qbr)
 
     # Append U_R
-    U_JC.cv_r(-omega_R*total_time, qmr[0])
+    U_JC.cv_r(-omega_R * total_time, qmr[0])
     # Append U_Q
-    U_JC.rz(omega_Q*total_time,qbr[0])
+    U_JC.rz(omega_Q * total_time, qbr[0])
     # Append U_\chi -- KS: this needs to be updated to reflect naming conventions in manuscript
-    U_JC.cv_c_r(-chi*total_time/2, qmr[0], qbr[0])
+    U_JC.cv_c_r(-chi * total_time / 2, qmr[0], qbr[0])
     # Compile this circuit into a single parameterized gate
-    U_JC = U_JC.to_gate(label='U_JC')
+    U_JC = U_JC.to_gate(label="U_JC")
 
     # Instantiate the circuit and initialize the qubit to the '0' state.
-    circuit_0 = c2qa.CVCircuit(qmr,qbr)
-    circuit_0.initialize([1,0], qbr)
+    circuit_0 = c2qa.CVCircuit(qmr, qbr)
+    circuit_0.initialize([1, 0], qbr)
 
     # Squeeze so we can visually see rotation
     circuit_0.cv_sq(0.5, qmr[0])
@@ -50,11 +52,9 @@ def __build_subcircuit():
     # coeffs = [numpy.exp(-numpy.abs(alpha)**2/2)*alpha**n/(numpy.sqrt(numpy.math.factorial(n))) for n in range(0,cutoff)]
     # circuit_0.cv_initialize(coeffs,qmr[0])
 
-
     # Append time evolution unitary
-    circuit_0.append(U_JC,qmr[0] + [qbr[0]])
+    circuit_0.append(U_JC, qmr[0] + [qbr[0]])
     # circuit_0.assign_parameters({dt : total_time})
-
 
     # dt = total_time
     # # Append U_R
@@ -67,8 +67,6 @@ def __build_subcircuit():
     # Compile this circuit into a single parameterized gate
     # U_JC = U_JC.to_gate(label='U_JC')
 
-
-
     # # Now repeat the above steps for a qubit initialized to the '1' state:
     # circuit_1 = c2qa.CVCircuit(qmr,qbr)
     # circuit_1.initialize([0,1], qbr)
@@ -80,25 +78,32 @@ def __build_subcircuit():
 
 
 def test_animate_subcircuit_one_gate(capsys):
-    """ Test animating a circuit with a composite gate built from another circuit.
-    Composite gate borrowed from Jaynes-Cummings model tutorial """
+    """Test animating a circuit with a composite gate built from another circuit.
+    Composite gate borrowed from Jaynes-Cummings model tutorial"""
 
     with capsys.disabled():
         circuit = __build_subcircuit()
 
         # Animate wigner function of each circuit
-        c2qa.animate.animate_wigner(circuit,file="tests/composite_gate.gif", animation_segments = 20)
+        c2qa.animate.animate_wigner(
+            circuit, file="tests/composite_gate.gif", animation_segments=20
+        )
 
 
 def test_animate_subcircuit_sequential(capsys):
-    """ Test animating a circuit with a composite gate built from another circuit.
-    Composite gate borrowed from Jaynes-Cummings model tutorial """
+    """Test animating a circuit with a composite gate built from another circuit.
+    Composite gate borrowed from Jaynes-Cummings model tutorial"""
 
     with capsys.disabled():
         circuit = __build_subcircuit()
 
         # Animate wigner function of each circuit
-        c2qa.animate.animate_wigner(circuit,file="tests/sequential_subcircuit.gif", animation_segments = 20, sequential_subcircuit = True)
+        c2qa.animate.animate_wigner(
+            circuit,
+            file="tests/sequential_subcircuit.gif",
+            animation_segments=20,
+            sequential_subcircuit=True,
+        )
 
 
 def test_animate_parameterized(capsys):
@@ -116,7 +121,7 @@ def test_animate_parameterized(capsys):
         minimal_circuit.cv_c_d(1j * a, qmr[0], qbr[0])
 
         bound_circuit = minimal_circuit.assign_parameters({a: 2})
-        
+
         wigner_filename = "tests/animate_parameterized.apng"
         c2qa.animate.animate_wigner(
             bound_circuit,

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -85,7 +85,7 @@ def test_get_qubit_indices(capsys):
         )
         qbr = qiskit.QuantumRegister(size=number_of_qubits)
         cbr = qiskit.ClassicalRegister(size=1)
-        circuit = c2qa.CVCircuit(qmr, qbr, cbr)  
+        circuit = c2qa.CVCircuit(qmr, qbr, cbr)
 
         indices = circuit.get_qubit_indices([qmr[1]])
         print(f"qmr[1] indices = {indices}")
@@ -103,6 +103,7 @@ def test_get_qubit_indices(capsys):
         print(f"qbr[0] indices = {indices}")
         assert indices == [4]
 
+
 def test_initialize_qubit_values(capsys):
     with capsys.disabled():
         print()
@@ -112,7 +113,8 @@ def test_initialize_qubit_values(capsys):
 
         for fock in range(pow(2, number_of_qubits_per_mode)):
             qmr = c2qa.QumodeRegister(
-                num_qumodes=number_of_modes, num_qubits_per_qumode=number_of_qubits_per_mode
+                num_qumodes=number_of_modes,
+                num_qubits_per_qumode=number_of_qubits_per_mode,
             )
             circuit = c2qa.CVCircuit(qmr)
             circuit.cv_initialize(fock, qmr[0])
@@ -130,15 +132,17 @@ def test_serialize(capsys):
         qumodes = c2qa.QumodeRegister(2)
         bosonic_circuit = c2qa.CVCircuit(qumodes)
 
-        init_state = [0,2]
+        init_state = [0, 2]
         for i in range(qumodes.num_qumodes):
             bosonic_circuit.cv_initialize(init_state[i], qumodes[i])
 
-        phi = qiskit.circuit.Parameter('phi')
-        bosonic_circuit.cv_bs(phi, qumodes[0], qumodes[1], qumodes.cutoff, qumodes.cutoff)
+        phi = qiskit.circuit.Parameter("phi")
+        bosonic_circuit.cv_bs(
+            phi, qumodes[0], qumodes[1], qumodes.cutoff, qumodes.cutoff
+        )
 
-        #print(bosonic_circuit.draw())
-        print('\nAttempt to serialize an unbound CVCircuit:')
+        # print(bosonic_circuit.draw())
+        print("\nAttempt to serialize an unbound CVCircuit:")
         bosonic_serial = json.dumps(bosonic_circuit, cls=RuntimeEncoder)
         print(bosonic_serial)
 
@@ -146,16 +150,22 @@ def test_serialize(capsys):
 def test_cv_gate_from_matrix(capsys):
     with capsys.disabled():
         # This test picks random qumode/qubit to initialize xgate on, does fockcounts, and checks that results match expected values.
-        xgate = [[0, 1],[1, 0]] # For qubit, flips |1> to |0> and vice versa. For qumode, flips fock |1> to fock |0> and vice versa
-        
+        xgate = [
+            [0, 1],
+            [1, 0],
+        ]  # For qubit, flips |1> to |0> and vice versa. For qumode, flips fock |1> to fock |0> and vice versa
+
         num_qumode_registers = 2
         num_qumodes_per_register = 2
         num_qubits_per_qumode = 1
 
         num_qubits = 3
 
-        total_qubits = num_qumode_registers * num_qumodes_per_register * num_qubits_per_qumode + num_qubits
-        for i in range(10): # Repeat test 10 times
+        total_qubits = (
+            num_qumode_registers * num_qumodes_per_register * num_qubits_per_qumode
+            + num_qubits
+        )
+        for i in range(10):  # Repeat test 10 times
             # Two qumode registers, One quantum register, One classical register. Hilbert space dimension = 2**(2 * 2 * 1 + 3) = 128
             qmr1 = c2qa.QumodeRegister(num_qumodes_per_register, num_qubits_per_qumode)
             qmr2 = c2qa.QumodeRegister(num_qumodes_per_register, num_qubits_per_qumode)
@@ -169,7 +179,7 @@ def test_cv_gate_from_matrix(capsys):
 
             for i in range(num_qubits):
                 circuit.initialize([0, 1], q[i])
-            
+
             # Pick one of the qumode registers to act on
             register = numpy.random.randint(1, 3)
 
@@ -180,16 +190,16 @@ def test_cv_gate_from_matrix(capsys):
             qubit_no = numpy.random.randint(0, 3)
 
             # Create string corresponding to expected results
-            expect = ['1' for _ in range(total_qubits)]
+            expect = ["1" for _ in range(total_qubits)]
 
             if register == 1:
-                expect[qumode_no] = '0'
+                expect[qumode_no] = "0"
             elif register == 2:
-                expect[qumode_no + 2] = '0'
+                expect[qumode_no + 2] = "0"
 
-            expect[4 + qubit_no] = '0' 
+            expect[4 + qubit_no] = "0"
 
-            expect = ''.join(reversed(expect))
+            expect = "".join(reversed(expect))
 
             # Depending on quantum register chosen, assert result to be true
             if register == 1:
@@ -204,7 +214,7 @@ def test_cv_gate_from_matrix(capsys):
                 if len(list(fock_counts.keys())) > 1:
                     raise Exception
 
-                assert(list(fock_counts.keys())[0] == expect)
+                assert list(fock_counts.keys())[0] == expect
 
             elif register == 2:
                 circuit.cv_gate_from_matrix(xgate, qmr2[qumode_no])
@@ -218,7 +228,7 @@ def test_cv_gate_from_matrix(capsys):
                 if len(list(fock_counts.keys())) > 1:
                     raise Exception
 
-                assert(list(fock_counts.keys())[0] == expect)
+                assert list(fock_counts.keys())[0] == expect
 
             else:
                 raise Exception
@@ -227,7 +237,7 @@ def test_cv_gate_from_matrix(capsys):
 def test_discretize_cv_gate_from_matrix(capsys):
     with capsys.disabled():
         # This test picks random qumode/qubit to initialize xgate on, does fockcounts, and checks that results match expected values.
-        xgate = [[0, 1],[1, 0]]
+        xgate = [[0, 1], [1, 0]]
 
         num_qumode_registers = 2
         num_qumodes_per_register = 2
@@ -235,7 +245,10 @@ def test_discretize_cv_gate_from_matrix(capsys):
 
         num_qubits = 3
 
-        total_qubits = num_qumode_registers * num_qumodes_per_register * num_qubits_per_qumode + num_qubits
+        total_qubits = (
+            num_qumode_registers * num_qumodes_per_register * num_qubits_per_qumode
+            + num_qubits
+        )
 
         # Two qumode registers, One quantum register, One classical register. Hilbert space dimension = 2**(2 * 2 * 1 + 3) = 128
         qmr1 = c2qa.QumodeRegister(num_qumodes_per_register, num_qubits_per_qumode)
@@ -251,11 +264,12 @@ def test_discretize_cv_gate_from_matrix(capsys):
         discretized = c2qa.discretize.discretize_circuits(circuit)
         assert len(circuit.data) == len(discretized)
 
+
 def test_cv_initialize(capsys):
     with capsys.disabled():
         qmr1 = c2qa.QumodeRegister(1, 2)
         qmr2 = c2qa.QumodeRegister(2, 2)
-        qmr3 = c2qa.QumodeRegister(2, 3) # <----- change to (2, 2) for no error
+        qmr3 = c2qa.QumodeRegister(2, 3)  # <----- change to (2, 2) for no error
         qmr4 = c2qa.QumodeRegister(1, 2)
         qmr5 = c2qa.QumodeRegister(3, 2)
         qmr6 = c2qa.QumodeRegister(3, 2)
@@ -269,5 +283,7 @@ def test_cv_initialize(capsys):
         circuit.cv_initialize([0, 1], qmr6[0])
 
         # saving a state vector for all the registers takes a considerable amount of time
-        state, result, fock_counts = c2qa.util.simulate(circuit, add_save_statevector=False, return_fockcounts=False)
+        state, result, fock_counts = c2qa.util.simulate(
+            circuit, add_save_statevector=False, return_fockcounts=False
+        )
         assert result.success

--- a/tests/test_discretize.py
+++ b/tests/test_discretize.py
@@ -21,7 +21,9 @@ def test_cv_c_d(capsys):
 
         gate = circuit.data[0].operation
         total_steps = 2
-        discretized_params = gate.calculate_segment_params(current_step=1, total_steps=total_steps, keep_state=True)
+        discretized_params = gate.calculate_segment_params(
+            current_step=1, total_steps=total_steps, keep_state=True
+        )
 
         print(f"Original theta={theta}")
         print(f"Discretized params {discretized_params}")
@@ -44,11 +46,15 @@ def test_cv_c_schwinger(capsys):
         phi_1 = random.random()
         theta_2 = random.random()
         phi_2 = random.random()
-        circuit.cv_c_schwinger([beta, theta_1, phi_1, theta_2, phi_2], qmr[0], qmr[1], qr[0])
+        circuit.cv_c_schwinger(
+            [beta, theta_1, phi_1, theta_2, phi_2], qmr[0], qmr[1], qr[0]
+        )
 
         gate = circuit.data[0].operation
         total_steps = 2
-        discretized_params = gate.calculate_segment_params(current_step=1, total_steps=total_steps, keep_state=True)
+        discretized_params = gate.calculate_segment_params(
+            current_step=1, total_steps=total_steps, keep_state=True
+        )
 
         print(f"Original params {(beta, theta_1, phi_1, theta_2, phi_2)}")
         print(f"Discretized params {discretized_params}")
@@ -60,7 +66,9 @@ def test_cv_c_schwinger(capsys):
         assert discretized_params[4] == phi_2
 
 
-@pytest.mark.skip(reason="Enable and test manually with debug breakpoint in__calculate_segment_params to ensure only first param is discretized")
+@pytest.mark.skip(
+    reason="Enable and test manually with debug breakpoint in__calculate_segment_params to ensure only first param is discretized"
+)
 def test_cv_c_schwinger_animate(capsys):
     """The cv_c_schwinger gate should discretize the first param, but the others not"""
     with capsys.disabled():
@@ -75,7 +83,9 @@ def test_cv_c_schwinger_animate(capsys):
         phi_1 = random.random()
         theta_2 = random.random()
         phi_2 = random.random()
-        circuit.cv_c_schwinger([beta, theta_1, phi_1, theta_2, phi_2], qmr[0], qmr[1], qr[0])
+        circuit.cv_c_schwinger(
+            [beta, theta_1, phi_1, theta_2, phi_2], qmr[0], qmr[1], qr[0]
+        )
 
         c2qa.animate.animate_wigner(
             circuit,
@@ -97,8 +107,16 @@ def test_discretize_with_pershot_statevector(capsys):
         circ.cv_delay(duration=100, qumode=qmr[0], unit="ns")
         circ.cv_measure(qmr[0], creg)
 
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=0.02, circuit=circ, time_unit="ns")
-        state, result, fock_counts = c2qa.util.simulate(circ, noise_passes=noise_pass, discretize=True, shots=2, per_shot_state_vector=True)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=0.02, circuit=circ, time_unit="ns"
+        )
+        state, result, fock_counts = c2qa.util.simulate(
+            circ,
+            noise_passes=noise_pass,
+            discretize=True,
+            shots=2,
+            per_shot_state_vector=True,
+        )
 
         assert result.success
 
@@ -110,8 +128,8 @@ def test_accumulated_counts_cv_c_r(capsys):
         cr = qiskit.circuit.ClassicalRegister(1)
         circ = c2qa.CVCircuit(qmr, anc, cr)
 
-        circ.initialize([1, 0], anc[0]) # Ancilla in |g>
-        circ.cv_initialize(3, qmr[0]) # Qumode in |3>
+        circ.initialize([1, 0], anc[0])  # Ancilla in |g>
+        circ.cv_initialize(3, qmr[0])  # Qumode in |3>
 
         # Photon number parity circuit
         circ.h(anc[0])
@@ -120,9 +138,13 @@ def test_accumulated_counts_cv_c_r(capsys):
         circ.measure(anc[0], cr[0])
 
         # Simulate
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=0.1, circuit=circ, time_unit="µs")
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=0.1, circuit=circ, time_unit="µs"
+        )
 
-        state, result, fock_counts = c2qa.util.simulate(circ, noise_passes=noise_pass, discretize=discretize, shots=3000)
+        state, result, fock_counts = c2qa.util.simulate(
+            circ, noise_passes=noise_pass, discretize=discretize, shots=3000
+        )
         print("##############")
         print(f"Result counts: {result.get_counts()}")
         print(f"Fock counts: {fock_counts}")
@@ -150,9 +172,13 @@ def test_accumulated_counts_cv_d(capsys):
 
         photon_loss_rate = 0.02
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit)
-    
-        state, result, fock_counts = c2qa.util.simulate(circuit, noise_passes=noise_pass, discretize=discretize, shots=200)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit
+        )
+
+        state, result, fock_counts = c2qa.util.simulate(
+            circuit, noise_passes=noise_pass, discretize=discretize, shots=200
+        )
         print("##############")
         print(f"Result counts: {result.get_counts()}")
         print(f"Fock counts: {fock_counts}")
@@ -166,6 +192,7 @@ def test_accumulated_counts_cv_d(capsys):
         print("DISCRETIZED")
         simulate_test(discretize=True)
 
+
 def test_manual_vs_auto_discretize(capsys):
     def simulate_test(manually_discretize: bool):
         qmr = c2qa.QumodeRegister(1, 3)
@@ -173,23 +200,30 @@ def test_manual_vs_auto_discretize(capsys):
         cr = qiskit.circuit.ClassicalRegister(1)
         circ = c2qa.CVCircuit(qmr, anc, cr)
 
-        circ.initialize([1, 0], anc[0]) # Ancilla in |g>
-        circ.cv_initialize(3, qmr[0]) # Qumode in |3>
+        circ.initialize([1, 0], anc[0])  # Ancilla in |g>
+        circ.cv_initialize(3, qmr[0])  # Qumode in |3>
 
         # Photon number parity circuit
         circ.h(anc[0])
         if manually_discretize:
-            for _ in range(10): # Manually discretize cv_c_r gate
-                circ.cv_c_r(numpy.pi/20, qmr[0], anc[0], duration=0.1, unit="µs")
+            for _ in range(10):  # Manually discretize cv_c_r gate
+                circ.cv_c_r(numpy.pi / 20, qmr[0], anc[0], duration=0.1, unit="µs")
         else:
-            circ.cv_c_r(numpy.pi/2, qmr[0], anc[0], duration=1, unit="µs")
+            circ.cv_c_r(numpy.pi / 2, qmr[0], anc[0], duration=1, unit="µs")
         circ.h(anc[0])
         circ.measure(anc[0], cr[0])
 
         # Simulate
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=0.1, circuit=circ, time_unit="µs")
-        return c2qa.util.simulate(circ, noise_passes=noise_pass, shots=3000, discretize=(not manually_discretize))
-    
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=0.1, circuit=circ, time_unit="µs"
+        )
+        return c2qa.util.simulate(
+            circ,
+            noise_passes=noise_pass,
+            shots=3000,
+            discretize=(not manually_discretize),
+        )
+
     with capsys.disabled():
         min_percent_diff = 99999
         max_percent_diff = 0
@@ -219,6 +253,6 @@ def test_manual_vs_auto_discretize(capsys):
                 max_percent_diff = max(percent_diff, max_percent_diff)
                 print(f"Key '{key}' percent difference {percent_diff}")
                 assert math.isclose(counts_man[key], counts_auto[key], rel_tol=0.25)
-        
+
         print(f"Min percent diff {min_percent_diff}")
         print(f"Max percent diff {max_percent_diff}")

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -89,6 +89,7 @@ def test_conditional_beamsplitter():
     # assert_changed(state, result)
     assert_unchanged(state, result)
 
+
 def test_conditional_schwinger():
     circuit, qmr, qr = create_conditional()
 
@@ -97,7 +98,9 @@ def test_conditional_schwinger():
     phi_1 = random.random()
     theta_2 = random.random()
     phi_2 = random.random()
-    circuit.cv_c_schwinger([beta, theta_1, phi_1, theta_2, phi_2], qmr[0], qmr[1], qr[0])
+    circuit.cv_c_schwinger(
+        [beta, theta_1, phi_1, theta_2, phi_2], qmr[0], qmr[1], qr[0]
+    )
 
     state, result, fock_counts = c2qa.util.simulate(circuit)
 
@@ -154,10 +157,11 @@ def test_displacement_once(capsys):
         state, result, fock_counts = c2qa.util.simulate(circuit)
         assert_changed(state, result)
 
+
 def test_cv_delay():
     circuit, qmr = create_unconditional()
 
-    circuit.cv_delay(100,qmr[0])
+    circuit.cv_delay(100, qmr[0])
 
     state, result, fock_counts = c2qa.util.simulate(circuit)
 
@@ -321,16 +325,25 @@ def test_eswap():
 
     state, result, fock_counts = c2qa.util.simulate(circuit)
 
+
 def test_multiboson_sampling(capsys):
     with capsys.disabled():
-        num_qubits=1
-        num_qumodes=2
-        num_qubits_per_qumode=2
-        qmrA = c2qa.QumodeRegister(num_qumodes = num_qumodes, num_qubits_per_qumode = num_qubits_per_qumode,name="qmrA_initial")
-        qmrB = c2qa.QumodeRegister(num_qumodes = num_qumodes, num_qubits_per_qumode = num_qubits_per_qumode,name="qmrB_initial")
-        qbr = qiskit.QuantumRegister(size=num_qubits,name='qbr_initial')
+        num_qubits = 1
+        num_qumodes = 2
+        num_qubits_per_qumode = 2
+        qmrA = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes,
+            num_qubits_per_qumode=num_qubits_per_qumode,
+            name="qmrA_initial",
+        )
+        qmrB = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes,
+            num_qubits_per_qumode=num_qubits_per_qumode,
+            name="qmrB_initial",
+        )
+        qbr = qiskit.QuantumRegister(size=num_qubits, name="qbr_initial")
         circuit = c2qa.CVCircuit(qmrA, qmrB, qbr)
-        circuit.cv_c_multiboson_sampling([0,1,2,3], qmrA[0], qbr[0])
+        circuit.cv_c_multiboson_sampling([0, 1, 2, 3], qmrA[0], qbr[0])
 
         state, result, fock_counts = c2qa.util.simulate(circuit)
         assert result.success

--- a/tests/test_inconsistent_statevectors.py
+++ b/tests/test_inconsistent_statevectors.py
@@ -32,11 +32,15 @@ def conditional_displacement_gate(circuit, arg_0, arg_1, qbit, qumode):
     op_1 = displacement_operator(arg_1)
 
     circuit.append(
-        qiskit.circuit.library.UnitaryGate(op_0).control(num_ctrl_qubits=1, ctrl_state=0),
+        qiskit.circuit.library.UnitaryGate(op_0).control(
+            num_ctrl_qubits=1, ctrl_state=0
+        ),
         [qbit] + qumode,
     )
     circuit.append(
-        qiskit.circuit.library.UnitaryGate(op_1).control(num_ctrl_qubits=1, ctrl_state=1),
+        qiskit.circuit.library.UnitaryGate(op_1).control(
+            num_ctrl_qubits=1, ctrl_state=1
+        ),
         [qbit] + qumode,
     )
 

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -40,10 +40,10 @@ def test_noise_model(capsys):
         time = 5.0  # seconds
         kraus_operators = c2qa.kraus.calculate_kraus(
             photon_loss_rates=[photon_loss_rate, photon_loss_rate],
-            time=time, 
+            time=time,
             circuit=circuit,
             op_qubits=[0, 1, 2],
-            qumode_qubit_indices=[0, 1]
+            qumode_qubit_indices=[0, 1],
         )
 
         print("kraus")
@@ -64,10 +64,10 @@ def test_kraus_operators(capsys):
         time = 1.0  # seconds
         kraus_operators = c2qa.kraus.calculate_kraus(
             photon_loss_rates=[photon_loss_rate, photon_loss_rate],
-            time=time, 
+            time=time,
             circuit=circuit,
             op_qubits=[0, 1, 2],
-            qumode_qubit_indices=[0, 1]
+            qumode_qubit_indices=[0, 1],
         )
 
         kraus = qiskit.quantum_info.operators.channel.Kraus(kraus_operators)
@@ -109,7 +109,9 @@ def test_beamsplitter_kraus_operators(capsys):
         num_qumodes = 2
         qubits_per_mode = 2
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode
+        )
         circuit = c2qa.CVCircuit(qmr)
         circuit.cv_initialize(2, qmr[0])
         circuit.cv_bs(1, qmr[1], qmr[0], duration=100, unit="ns")
@@ -117,10 +119,10 @@ def test_beamsplitter_kraus_operators(capsys):
         time = 1.0  # seconds
         kraus_operators = c2qa.kraus.calculate_kraus(
             photon_loss_rates=[photon_loss_rate, photon_loss_rate],
-            time=time, 
+            time=time,
             circuit=circuit,
             op_qubits=[2, 3, 0, 1],
-            qumode_qubit_indices=[0, 1, 2, 3]
+            qumode_qubit_indices=[0, 1, 2, 3],
         )
 
         kraus = qiskit.quantum_info.operators.channel.Kraus(kraus_operators)
@@ -162,15 +164,21 @@ def test_invalid_photon_loss_rate_length(capsys):
         num_qumodes = 2
         qubits_per_mode = 2
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode
+        )
         init_circuit = c2qa.CVCircuit(qmr)
         init_circuit.cv_initialize(2, qmr[0])
         init_circuit.cv_bs(1, qmr[1], qmr[0], duration=100, unit="ns")
-        photon_loss_rates = [1,2,3]  # Should only have two loss rates
+        photon_loss_rates = [1, 2, 3]  # Should only have two loss rates
         time_unit = "ns"
 
         # Should raise Exception for not having proper number of loss rates
-        c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rates, circuit=init_circuit, time_unit=time_unit)
+        c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rates,
+            circuit=init_circuit,
+            time_unit=time_unit,
+        )
 
 
 def test_valid_photon_loss_rate_length(capsys):
@@ -178,15 +186,21 @@ def test_valid_photon_loss_rate_length(capsys):
         num_qumodes = 2
         qubits_per_mode = 2
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode
+        )
         init_circuit = c2qa.CVCircuit(qmr)
         init_circuit.cv_initialize(2, qmr[0])
         init_circuit.cv_bs(1, qmr[1], qmr[0], duration=100, unit="ns")
-        photon_loss_rates = [1,2]  # Should only have two loss rates
+        photon_loss_rates = [1, 2]  # Should only have two loss rates
         time_unit = "ns"
-        
+
         # Should not raise exception as has proper number of loss rates
-        c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rates, circuit=init_circuit, time_unit=time_unit)
+        c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rates,
+            circuit=init_circuit,
+            time_unit=time_unit,
+        )
 
 
 def test_noise_with_beamsplitter(capsys):
@@ -194,14 +208,22 @@ def test_noise_with_beamsplitter(capsys):
         num_qumodes = 2
         qubits_per_mode = 2
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode
+        )
         init_circuit = c2qa.CVCircuit(qmr)
         init_circuit.cv_initialize(2, qmr[0])
         init_circuit.cv_bs(1, qmr[1], qmr[0], duration=100, unit="ns")
         photon_loss_rate = 0.01
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=init_circuit, time_unit=time_unit)
-        state, result, fock_counts = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate,
+            circuit=init_circuit,
+            time_unit=time_unit,
+        )
+        state, result, fock_counts = c2qa.util.simulate(
+            init_circuit, noise_passes=noise_pass
+        )
 
 
 def test_noise_with_beamsplitter_diff_cutoff(capsys):
@@ -214,8 +236,14 @@ def test_noise_with_beamsplitter_diff_cutoff(capsys):
         init_circuit.cv_bs(1, qmr1[0], qmr2[0], duration=100, unit="ns")
         photon_loss_rate = 0.01
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=init_circuit, time_unit=time_unit)
-        state, result, fock_counts = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate,
+            circuit=init_circuit,
+            time_unit=time_unit,
+        )
+        state, result, fock_counts = c2qa.util.simulate(
+            init_circuit, noise_passes=noise_pass
+        )
 
 
 @pytest.mark.skip(reason="This test takes nearly 30 minutes to pass on Github...")
@@ -230,8 +258,14 @@ def test_noise_with_cbs_diff_cutoff(capsys):
         init_circuit.cv_c_bs(1, qmr1[0], qmr2[0], qbr[0], duration=100, unit="ns")
         photon_loss_rate = 0.01
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=init_circuit, time_unit=time_unit)
-        state, result, fock_counts = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate,
+            circuit=init_circuit,
+            time_unit=time_unit,
+        )
+        state, result, fock_counts = c2qa.util.simulate(
+            init_circuit, noise_passes=noise_pass
+        )
 
 
 def test_noise_with_sq2_diff_cutoff(capsys):
@@ -244,9 +278,15 @@ def test_noise_with_sq2_diff_cutoff(capsys):
         init_circuit.cv_sq2(1, qmr1[0], qmr2[0], duration=100, unit="ns")
         photon_loss_rate = 0.01
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=init_circuit, time_unit=time_unit)
-        state, result, fock_counts = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
-    
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate,
+            circuit=init_circuit,
+            time_unit=time_unit,
+        )
+        state, result, fock_counts = c2qa.util.simulate(
+            init_circuit, noise_passes=noise_pass
+        )
+
 
 def test_noise_with_cnd_beamsplitter(capsys):
     with capsys.disabled():
@@ -254,15 +294,23 @@ def test_noise_with_cnd_beamsplitter(capsys):
         qubits_per_mode = 2
         num_qubits = 1
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode
+        )
         qbr = qiskit.QuantumRegister(size=num_qubits)
         init_circuit = c2qa.CVCircuit(qmr, qbr)
         init_circuit.cv_initialize(2, qmr[0])
         init_circuit.cv_c_bs(1, qmr[1], qmr[0], qbr[0], duration=100, unit="ns")
         photon_loss_rate = 0.01
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=init_circuit, time_unit=time_unit)
-        state, result, fock_counts = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate,
+            circuit=init_circuit,
+            time_unit=time_unit,
+        )
+        state, result, fock_counts = c2qa.util.simulate(
+            init_circuit, noise_passes=noise_pass
+        )
 
 
 def test_photon_loss_pass_with_conditional(capsys):
@@ -271,15 +319,23 @@ def test_photon_loss_pass_with_conditional(capsys):
         qubits_per_mode = 2
         num_qubits = 1
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode
+        )
         qbr = qiskit.QuantumRegister(size=num_qubits)
         init_circuit = c2qa.CVCircuit(qmr, qbr)
         init_circuit.cv_initialize(2, qmr[0])
         init_circuit.cv_c_d(1, qmr[0], qbr[0], duration=100, unit="ns")
         photon_loss_rate = 0.01
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=init_circuit, time_unit=time_unit)
-        state, result, fock_counts = c2qa.util.simulate(init_circuit, noise_passes=noise_pass)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate,
+            circuit=init_circuit,
+            time_unit=time_unit,
+        )
+        state, result, fock_counts = c2qa.util.simulate(
+            init_circuit, noise_passes=noise_pass
+        )
 
 
 def test_photon_loss_pass_delay_without_unit(capsys):
@@ -288,17 +344,25 @@ def test_photon_loss_pass_delay_without_unit(capsys):
         qubits_per_mode = 2
         num_qubits = 1
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode
+        )
         qbr = qiskit.QuantumRegister(size=num_qubits)
 
         fail_circuit = c2qa.CVCircuit(qmr, qbr)
         fail_circuit.cv_initialize(2, qmr[0])
-        fail_circuit.delay(duration=100) #, unit="ns")
+        fail_circuit.delay(duration=100)  # , unit="ns")
         fail_circuit.cv_c_d(1, qmr[0], qbr[0], duration=100, unit="ns")
         photon_loss_rate = 0.01
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=fail_circuit, time_unit=time_unit)
-        state, result, fock_counts = c2qa.util.simulate(fail_circuit, noise_passes=noise_pass)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate,
+            circuit=fail_circuit,
+            time_unit=time_unit,
+        )
+        state, result, fock_counts = c2qa.util.simulate(
+            fail_circuit, noise_passes=noise_pass
+        )
         assert result.success
 
 
@@ -308,7 +372,9 @@ def test_photon_loss_pass_delay_with_unit(capsys):
         qubits_per_mode = 2
         num_qubits = 1
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode
+        )
         qbr = qiskit.QuantumRegister(size=num_qubits)
 
         pass_circuit = c2qa.CVCircuit(qmr, qbr)
@@ -317,8 +383,14 @@ def test_photon_loss_pass_delay_with_unit(capsys):
         pass_circuit.cv_c_d(1, qmr[0], qbr[0], duration=100, unit="ns")
         photon_loss_rate = 0.01
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=pass_circuit, time_unit=time_unit)
-        state, result, fock_counts = c2qa.util.simulate(pass_circuit, noise_passes=noise_pass)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate,
+            circuit=pass_circuit,
+            time_unit=time_unit,
+        )
+        state, result, fock_counts = c2qa.util.simulate(
+            pass_circuit, noise_passes=noise_pass
+        )
         assert result.success
 
 
@@ -335,7 +407,9 @@ def test_animate_photon_loss_pass(capsys):
 
         photon_loss_rate = 0.01
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit
+        )
 
         wigner_filename = "tests/test_animate_photon_loss_pass.gif"
         c2qa.animate.animate_wigner(
@@ -360,7 +434,9 @@ def test_animate_photon_loss_pass_with_epsilon(capsys):
 
         photon_loss_rate = 0.01
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit
+        )
 
         wigner_filename = "tests/test_animate_photon_loss_pas_with_epsilon.gif"
         c2qa.animate.animate_wigner(
@@ -386,7 +462,9 @@ def test_photon_loss_pass_no_displacement(capsys):
 
         photon_loss_rate = 0.01
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit
+        )
 
         # state, result, fock_counts = c2qa.util.simulate(circuit, noise_passes=noise_pass)
 
@@ -413,7 +491,9 @@ def test_photon_loss_pass_slow_displacement(capsys):
 
         photon_loss_rate = 0.02
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit
+        )
 
         # state, result, fock_counts = c2qa.util.simulate(circuit, noise_passes=noise_pass)
 
@@ -434,7 +514,9 @@ def test_photon_loss_pass_slow_conditional_displacement(capsys):
         num_qubits_per_qumode = 4
         num_qubits = 1
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode
+        )
         qbr = qiskit.QuantumRegister(size=num_qubits)
         circuit = c2qa.CVCircuit(qmr, qbr)
 
@@ -444,11 +526,15 @@ def test_photon_loss_pass_slow_conditional_displacement(capsys):
 
         photon_loss_rate = 0.02
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit)
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit
+        )
 
         # state, result, fock_counts = c2qa.util.simulate(circuit, noise_passes=noise_pass)
 
-        wigner_filename = "tests/test_photon_loss_pass_slow_conditional_displacement.mp4"
+        wigner_filename = (
+            "tests/test_photon_loss_pass_slow_conditional_displacement.mp4"
+        )
         c2qa.animate.animate_wigner(
             circuit,
             animation_segments=200,
@@ -463,7 +549,9 @@ def test_photon_loss_instruction(capsys):
         num_qubits_per_qumode = 2
         num_qubits = 1
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode
+        )
         qbr = qiskit.QuantumRegister(size=num_qubits)
         circuit = c2qa.CVCircuit(qmr, qbr)
 
@@ -475,9 +563,16 @@ def test_photon_loss_instruction(capsys):
 
         photon_loss_rate = 0.02
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit, instructions=["cD"])
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate,
+            circuit=circuit,
+            time_unit=time_unit,
+            instructions=["cD"],
+        )
 
-        state, result, fock_counts = c2qa.util.simulate(circuit, noise_passes=noise_pass)
+        state, result, fock_counts = c2qa.util.simulate(
+            circuit, noise_passes=noise_pass
+        )
         assert result.success
 
 
@@ -487,7 +582,9 @@ def test_photon_loss_qumode(capsys):
         num_qubits_per_qumode = 2
         num_qubits = 1
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode
+        )
         qbr = qiskit.QuantumRegister(size=num_qubits)
         circuit = c2qa.CVCircuit(qmr, qbr)
 
@@ -498,9 +595,16 @@ def test_photon_loss_qumode(capsys):
 
         photon_loss_rate = 0.02
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit, qumodes=qmr[1])
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate,
+            circuit=circuit,
+            time_unit=time_unit,
+            qumodes=qmr[1],
+        )
 
-        state, result, fock_counts = c2qa.util.simulate(circuit, noise_passes=noise_pass)
+        state, result, fock_counts = c2qa.util.simulate(
+            circuit, noise_passes=noise_pass
+        )
         assert result.success
 
 
@@ -510,7 +614,9 @@ def test_photon_loss_instruction_qumode(capsys):
         num_qubits_per_qumode = 2
         num_qubits = 1
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode
+        )
         qbr = qiskit.QuantumRegister(size=num_qubits)
         circuit = c2qa.CVCircuit(qmr, qbr)
 
@@ -521,9 +627,17 @@ def test_photon_loss_instruction_qumode(capsys):
 
         photon_loss_rate = 0.02
         time_unit = "ns"
-        noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit=time_unit, instructions=["cD"], qumodes=qmr[0])
+        noise_pass = c2qa.kraus.PhotonLossNoisePass(
+            photon_loss_rates=photon_loss_rate,
+            circuit=circuit,
+            time_unit=time_unit,
+            instructions=["cD"],
+            qumodes=qmr[0],
+        )
 
-        state, result, fock_counts = c2qa.util.simulate(circuit, noise_passes=noise_pass)
+        state, result, fock_counts = c2qa.util.simulate(
+            circuit, noise_passes=noise_pass
+        )
         assert result.success
 
 
@@ -538,14 +652,16 @@ def test_photon_loss_and_phase_damping(capsys):
         assert result_b.success
 
         assert not allclose(state_a, state_b)
-    
 
-def _build_photon_loss_and_amp_damping_circuit(amp_damp = 0.3, photon_loss_rate = 0.01):
+
+def _build_photon_loss_and_amp_damping_circuit(amp_damp=0.3, photon_loss_rate=0.01):
     num_qumodes = 1
     qubits_per_mode = 2
     num_qubits = 1
 
-    qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode)
+    qmr = c2qa.QumodeRegister(
+        num_qumodes=num_qumodes, num_qubits_per_qumode=qubits_per_mode
+    )
     qbr = qiskit.QuantumRegister(size=num_qubits)
     circuit = c2qa.CVCircuit(qmr, qbr)
     circuit.cv_initialize(2, qmr[0])
@@ -558,7 +674,9 @@ def _build_photon_loss_and_amp_damping_circuit(amp_damp = 0.3, photon_loss_rate 
     noise_model.add_quantum_error(phase_error, ["x"], [circuit.get_qubit_index(qbr[0])])
 
     # Initialize PhotonLossNoisePass
-    noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit="ns")
+    noise_pass = c2qa.kraus.PhotonLossNoisePass(
+        photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit="ns"
+    )
 
     return c2qa.util.simulate(circuit, noise_model=noise_model, noise_passes=noise_pass)
 
@@ -582,7 +700,9 @@ def test_relaxation_noise_pass(capsys):
         num_qubits_per_qumode = 2
         num_qubits = 1
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode
+        )
         qbr = qiskit.QuantumRegister(size=num_qubits)
         circuit = c2qa.CVCircuit(qmr, qbr)
 
@@ -610,7 +730,9 @@ def test_relaxation_and_photon_loss_noise_passes(capsys):
         num_qubits_per_qumode = 2
         num_qubits = 1
 
-        qmr = c2qa.QumodeRegister(num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode)
+        qmr = c2qa.QumodeRegister(
+            num_qumodes=num_qumodes, num_qubits_per_qumode=num_qubits_per_qumode
+        )
         qbr = qiskit.QuantumRegister(size=num_qubits)
         circuit = c2qa.CVCircuit(qmr, qbr)
 
@@ -625,7 +747,11 @@ def test_relaxation_and_photon_loss_noise_passes(capsys):
         noise_passes.append(RelaxationNoisePass(t1s, t2s))
 
         photon_loss_rate = 0.02
-        noise_passes.append(c2qa.kraus.PhotonLossNoisePass(photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit="ns"))
+        noise_passes.append(
+            c2qa.kraus.PhotonLossNoisePass(
+                photon_loss_rates=photon_loss_rate, circuit=circuit, time_unit="ns"
+            )
+        )
 
         filename = "tests/test_relaxation_and_photon_loss_noise_passes.gif"
         c2qa.animate.animate_wigner(
@@ -646,8 +772,8 @@ def test_multi_qumode_loss_probability(capsys):
 
         circuit.cv_initialize(1, qmr[0])
         circuit.cv_initialize(1, qmr[1])
-        circuit.cv_bs(np.pi/4, qmr[0], qmr[1], duration=100, unit="ns")
-        circuit.cv_bs(-np.pi/4, qmr[0], qmr[1], duration=100, unit="ns")
+        circuit.cv_bs(np.pi / 4, qmr[0], qmr[1], duration=100, unit="ns")
+        circuit.cv_bs(-np.pi / 4, qmr[0], qmr[1], duration=100, unit="ns")
 
         photon_loss_rate = 10000000
         noise_pass = c2qa.kraus.PhotonLossNoisePass(photon_loss_rate, circuit)
@@ -657,9 +783,13 @@ def test_multi_qumode_loss_probability(capsys):
         for i in range(20):
             print("----------------------")
             print(f"Iteration {i}")
-            state_vector, result, fock_counts = c2qa.util.simulate(circuit, noise_passes=noise_pass)
+            state_vector, result, fock_counts = c2qa.util.simulate(
+                circuit, noise_passes=noise_pass
+            )
             # plot_histogram(result.get_counts(circuit), filename=f"tests/test_manual_validate_beamsplitter-{i}.png")
-            occupation, fock_states = c2qa.util.stateread(state_vector, 0, num_qumodes, 2**num_qubits_per_qumode,verbose=True)
+            occupation, fock_states = c2qa.util.stateread(
+                state_vector, 0, num_qumodes, 2**num_qubits_per_qumode, verbose=True
+            )
 
             for qumode_state, qubit_state, amplitude in fock_states:
                 # print(f"{qumode_state} {qubit_state} {amplitude}")
@@ -667,8 +797,11 @@ def test_multi_qumode_loss_probability(capsys):
                 qumode2 = qumode_state[1]
                 probability = amplitude**2
 
-                if (qumode1 == 1 and qumode2 == 0) or (qumode1 == 0 and qumode1 == 1) and math.isclose(probability, 0.5, 0.03):
+                if (
+                    (qumode1 == 1 and qumode2 == 0)
+                    or (qumode1 == 0 and qumode1 == 1)
+                    and math.isclose(probability, 0.5, 0.03)
+                ):
                     fifty_fifty = True
-            
+
         assert fifty_fifty
-        

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -148,31 +148,43 @@ def test_stateread(capsys):
             verbose=True,
         )
 
+
 def test_fockmap(capsys):
     with capsys.disabled():
 
         # Build rand array of rand dim between 1 and 100, use fockmap to populate initally empty array, and assert that final array is equal to rand array
-        for _ in range(10): # Repeat test 10 times
+        for _ in range(10):  # Repeat test 10 times
             dim = numpy.random.randint(low=1, high=101)
             randarray = numpy.random.uniform(low=0, high=1, size=(dim, dim))
 
             testmatrix = numpy.zeros((dim, dim))
             for i in range(dim):
-                for j in range (dim):
+                for j in range(dim):
                     testmatrix = c2qa.util.fockmap(testmatrix, j, i, randarray[i, j])
-                     
-            assert((testmatrix == randarray).all())
+
+            assert (testmatrix == randarray).all()
 
         # Check fockmap using numpy.outer
         matrix = numpy.zeros((4, 4))
-        assert((c2qa.util.fockmap(matrix, 0, 0) == numpy.outer([1, 0, 0 ,0], [1, 0, 0, 0])).all()) # |0><0|
-        assert((c2qa.util.fockmap(matrix, 1, [3, 2], [1, 0.5]) == (numpy.outer([0, 0, 0 ,1], [0, 1, 0, 0]) + 0.5 * numpy.outer([0, 0, 1 ,0], [0, 1, 0, 0]))).all()) # |3><1| + 0.5|2><1|
-        assert((c2qa.util.fockmap(matrix, 1, [3, 2, 1]) == c2qa.util.fockmap(matrix, [1, 1, 1], [3, 2, 1])).all()) # |3><1| + |2><1| + |1><1|
+        assert (
+            c2qa.util.fockmap(matrix, 0, 0) == numpy.outer([1, 0, 0, 0], [1, 0, 0, 0])
+        ).all()  # |0><0|
+        assert (
+            c2qa.util.fockmap(matrix, 1, [3, 2], [1, 0.5])
+            == (
+                numpy.outer([0, 0, 0, 1], [0, 1, 0, 0])
+                + 0.5 * numpy.outer([0, 0, 1, 0], [0, 1, 0, 0])
+            )
+        ).all()  # |3><1| + 0.5|2><1|
+        assert (
+            c2qa.util.fockmap(matrix, 1, [3, 2, 1])
+            == c2qa.util.fockmap(matrix, [1, 1, 1], [3, 2, 1])
+        ).all()  # |3><1| + |2><1| + |1><1|
 
         # Check the types which are accepted for each arg.
         for i in range(10):
             # Nested list, numpy.ndarray
-            m_types = [[[0, 0],[0 ,0]], numpy.zeros((2, 2))] 
+            m_types = [[[0, 0], [0, 0]], numpy.zeros((2, 2))]
 
             # int, list
             fi_types = [0, [1, 0]]
@@ -180,7 +192,7 @@ def test_fockmap(capsys):
             # int, list
             fo_types = [1, [1, 0]]
 
-            #int, float, complex, empty list, list, numpy.ndarray
+            # int, float, complex, empty list, list, numpy.ndarray
             amp_types = [1, 1.0, 1j, [], [1, 1], numpy.array([1, 1])]
 
             # Generate random indices to test for
@@ -192,11 +204,21 @@ def test_fockmap(capsys):
                 amp_index = numpy.random.randint(0, 4)
             else:
                 amp_index = numpy.random.randint(3, 5)
-            
-            # Assert that output is a numpy.ndarray
-            assert(type(c2qa.util.fockmap(m_types[m_index], fi_types[fi_index], fo_types[fo_index], amp_types[amp_index])) == numpy.ndarray)
 
-        
+            # Assert that output is a numpy.ndarray
+            assert (
+                type(
+                    c2qa.util.fockmap(
+                        m_types[m_index],
+                        fi_types[fi_index],
+                        fo_types[fo_index],
+                        amp_types[amp_index],
+                    )
+                )
+                == numpy.ndarray
+            )
+
+
 def test_circuit_avg_photon_num(capsys):
     with capsys.disabled():
         # Create two qumode registers containing 2 qumodes and 1 qumode respectively.
@@ -205,9 +227,9 @@ def test_circuit_avg_photon_num(capsys):
         circ = c2qa.CVCircuit(qmr1, qmr2)
 
         # Initialize the three qumodes to |3>, |4>, |5> Fock states.
-        circ.cv_initialize(3, qmr1[0]) # Qumode in |3>
-        circ.cv_initialize(4, qmr1[1]) # Qumode in |4>
-        circ.cv_initialize(5, qmr2[0]) # Qumode in |5>
+        circ.cv_initialize(3, qmr1[0])  # Qumode in |3>
+        circ.cv_initialize(4, qmr1[1])  # Qumode in |4>
+        circ.cv_initialize(5, qmr2[0])  # Qumode in |5>
 
         # Print out the indices of qubits in qumodes, grouped by qumode
         print(circ.qumode_qubits_indices_grouped)
@@ -218,27 +240,33 @@ def test_circuit_avg_photon_num(capsys):
 
         avg_photon_num = c2qa.util.avg_photon_num(circ, state)
         print(avg_photon_num)
-        assert([3.0, 4.0, 5.0] == avg_photon_num)
+        assert [3.0, 4.0, 5.0] == avg_photon_num
 
 
 def test_qumode_avg_photon_num(capsys):
     with capsys.disabled():
-        for _ in range(5): # Repeat test 5 times
+        for _ in range(5):  # Repeat test 5 times
             # Decimals
             decimals = numpy.random.randint(1, 6)
-            
+
             # Generate random vector
             dim = numpy.random.randint(1, 11)
-            vector = numpy.random.uniform(-1, 1, dim) + 1.j * numpy.random.uniform(-1, 1, dim)
-            
+            vector = numpy.random.uniform(-1, 1, dim) + 1.0j * numpy.random.uniform(
+                -1, 1, dim
+            )
+
             # Compute magnitude of each element within vector, and norm of vector
             element_norm = numpy.multiply(vector, numpy.conjugate(vector))
             norm = numpy.sum(element_norm)
 
             # Dot product between number operator and magnitude
-            avg_num = numpy.mean(numpy.dot(element_norm, numpy.array(range(dim))))/norm
-            
+            avg_num = (
+                numpy.mean(numpy.dot(element_norm, numpy.array(range(dim)))) / norm
+            )
+
             # Average photon number of statevector, density matrix, and random vector must all match
-            assert(c2qa.util.qumode_avg_photon_num(Statevector(vector), decimals) == c2qa.util.qumode_avg_photon_num(DensityMatrix(vector), decimals) == round(avg_num.real, decimals))
-            
-            
+            assert (
+                c2qa.util.qumode_avg_photon_num(Statevector(vector), decimals)
+                == c2qa.util.qumode_avg_photon_num(DensityMatrix(vector), decimals)
+                == round(avg_num.real, decimals)
+            )

--- a/tests/test_wigner.py
+++ b/tests/test_wigner.py
@@ -58,7 +58,10 @@ def test_plot_wigner_projection(capsys):
         circuit.cv_c_d(dist, qmr[0], qr[0])
         # circuit.cv_d(dist, qmr[0])
 
-        c2qa.wigner.plot_wigner_projection(circuit, qr[0], file="tests/interference.png")
+        c2qa.wigner.plot_wigner_projection(
+            circuit, qr[0], file="tests/interference.png"
+        )
+
 
 def test_cat_state_wigner_plot(capsys):
     with capsys.disabled():
@@ -81,7 +84,9 @@ def test_cat_state_wigner_plot(capsys):
         circuit.measure(qr[0], cr[0])
 
         # conditional_state_vector=True will return two state vectors, one for 0 and 1 classical register value
-        state, result, fock_counts = c2qa.util.simulate(circuit, conditional_state_vector=True)
+        state, result, fock_counts = c2qa.util.simulate(
+            circuit, conditional_state_vector=True
+        )
         even_state = state["0x0"]
         odd_state = state["0x1"]
 
@@ -138,7 +143,9 @@ def test_wigner_mle(capsys):
         circuit.cv_c_d(dist, qmr[0], qr[0])
         circuit.h(qr[0])
 
-        state, result, fock_counts = c2qa.util.simulate(circuit, per_shot_state_vector=True)
+        state, result, fock_counts = c2qa.util.simulate(
+            circuit, per_shot_state_vector=True
+        )
         wigner = c2qa.wigner.wigner_mle(state)
         assert wigner is not None
         print(wigner)


### PR DESCRIPTION
In Qiskit 1.2, the protect member `_parameter_table` of the `QuantumCircuit` class is managed in the Rust domain and is inaccessible from Python. (It is further explained in this [Qiskit PR](https://github.com/qiskit-community/qiskit-experiments/pull/1465)). This PR removes reference to the parameter table in the `CVCircuit` class, which had no downstream dependencies. Now `bosonic-qiskit` should be compatible with Qiskit >= 1.2.

Also fixed some formatting issues by running `black`.