### PR TITLE
Fix GitHub workflows by changing to .gif in tests and examples

### DIFF
--- a/.github/workflows/jupyter-matrix.yml
+++ b/.github/workflows/jupyter-matrix.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Setup FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v3
-
       - name: Setup TeX Live
         uses: teatimeguest/setup-texlive-action@v3
         with:

--- a/.github/workflows/jupyter-matrix.yml
+++ b/.github/workflows/jupyter-matrix.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Setup FFmpeg
+        uses: FedericoCarboni/setup-ffmpeg@v3
+
       - name: Setup TeX Live
         uses: teatimeguest/setup-texlive-action@v3
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,9 +25,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Setup FFmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v3
-
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/tests/test_animate.py
+++ b/tests/test_animate.py
@@ -207,7 +207,6 @@ def test_animate_without_trace(capsys):
         __animate_without_cbit("tests/animate_without_trace.gif", False)
 
 
-@pytest.mark.skip(reason="GitHub actions build environments do not have ffmpeg")
 def test_calibration_animate_mp4(capsys):
     with capsys.disabled():
         qmr = c2qa.QumodeRegister(num_qumodes=1, num_qubits_per_qumode=6)
@@ -230,7 +229,7 @@ def test_calibration_animate_mp4(capsys):
             circuit,
             qubit=qr[0],
             cbit=cr[0],
-            file="tests/displacement.mp4",
+            file="tests/displacement.gif",
             axes_min=-8,
             axes_max=8,
             animation_segments=48,

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -372,7 +372,6 @@ def test_animate_photon_loss_pass_with_epsilon(capsys):
         assert Path(wigner_filename).is_file()
 
 
-@pytest.mark.skip(reason="GitHub actions build environments do not have ffmpeg")
 def test_photon_loss_pass_no_displacement(capsys):
     with capsys.disabled():
         num_qumodes = 1
@@ -390,7 +389,7 @@ def test_photon_loss_pass_no_displacement(capsys):
 
         # state, result, fock_counts = c2qa.util.simulate(circuit, noise_passes=noise_pass)
 
-        wigner_filename = "tests/test_photon_loss_pass_no_displacement.mp4"
+        wigner_filename = "tests/test_photon_loss_pass_no_displacement.gif"
         c2qa.animate.animate_wigner(
             circuit,
             animation_segments=200,
@@ -399,7 +398,6 @@ def test_photon_loss_pass_no_displacement(capsys):
         )
 
 
-@pytest.mark.skip(reason="GitHub actions build environments do not have ffmpeg")
 def test_photon_loss_pass_slow_displacement(capsys):
     with capsys.disabled():
         num_qumodes = 1
@@ -417,7 +415,7 @@ def test_photon_loss_pass_slow_displacement(capsys):
 
         # state, result, fock_counts = c2qa.util.simulate(circuit, noise_passes=noise_pass)
 
-        wigner_filename = "tests/test_photon_loss_pass_slow_displacement.mp4"
+        wigner_filename = "tests/test_photon_loss_pass_slow_displacement.gif"
         c2qa.animate.animate_wigner(
             circuit,
             animation_segments=200,
@@ -427,7 +425,6 @@ def test_photon_loss_pass_slow_displacement(capsys):
         )
 
 
-@pytest.mark.skip(reason="GitHub actions build environments do not have ffmpeg")
 def test_photon_loss_pass_slow_conditional_displacement(capsys):
     with capsys.disabled():
         num_qumodes = 1
@@ -448,7 +445,7 @@ def test_photon_loss_pass_slow_conditional_displacement(capsys):
 
         # state, result, fock_counts = c2qa.util.simulate(circuit, noise_passes=noise_pass)
 
-        wigner_filename = "tests/test_photon_loss_pass_slow_conditional_displacement.mp4"
+        wigner_filename = "tests/test_photon_loss_pass_slow_conditional_displacement.gif"
         c2qa.animate.animate_wigner(
             circuit,
             animation_segments=200,

--- a/tutorials/medium_article/examples.ipynb
+++ b/tutorials/medium_article/examples.ipynb
@@ -528,7 +528,7 @@
     "c2qa.animate.animate_wigner(\n",
     "    circuit,\n",
     "    animation_segments=200,\n",
-    "    file=wigner_filename,\n",
+    "    # file=wigner_filename,\n",
     "    noise_passes=noise_pass\n",
     ")   "
    ]

--- a/tutorials/medium_article/examples.ipynb
+++ b/tutorials/medium_article/examples.ipynb
@@ -524,11 +524,11 @@
     "state, result, _ = c2qa.util.simulate(circuit, noise_passes=noise_pass)\n",
     "\n",
     "# Alternatively, we can animate our circuit using the animate_wigner() function built-into bosonic qiskit.\n",
-    "wigner_filename = \"figures/photon_loss.mp4\"\n",
+    "wigner_filename = \"figures/photon_loss.gif\"\n",
     "c2qa.animate.animate_wigner(\n",
     "    circuit,\n",
     "    animation_segments=200,\n",
-    "    # file=wigner_filename,\n",
+    "    file=wigner_filename,\n",
     "    noise_passes=noise_pass\n",
     ")   "
    ]
@@ -550,7 +550,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR addresses #124.

The latest version of the mac-os GitHub Workflow runner uses Apple Silicon which the setup-ffmpeg from Github workflows is incompatible with (does not have ffmpeg support for Apple Silicon).

The choices in this PR is to support Apple Silicon for testing and change any use of `.mp4` to `.gif` in various tests and examples for GitHub Workflows/Actions to pass.