### PR TITLE
Bugfix/deprecation warnings

### DIFF
--- a/c2qa/util.py
+++ b/c2qa/util.py
@@ -325,7 +325,7 @@ def _final_measurement_mapping(circuit):
     qmap = []
     cmap = []
     for item in circuit._data[::-1]:
-        if item[0].name == "measure":
+        if item.name == "measure":
             cbit = cint_map[item[2][0]]
             qbit = qint_map[item[1][0]]
             if cbit in active_cbits and qbit in active_qubits:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,13 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "qiskit==1.2.4",
-    "qiskit_aer==0.15.1",
-    "qiskit-ibm-runtime==0.31.0",
+    "qiskit==1.3.0",
+    "qiskit-aer==0.15.1",
+    "qiskit-ibm-runtime==0.33.2",
     "qutip==5.0.4",
-    "matplotlib==3.9.2",
+    "matplotlib==3.9.3",
     "pylatexenc==2.10",
-    "numpy>=2.0.0",
+    "numpy==2.0.2",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-qiskit==1.2.4
+qiskit==1.3.0
 qiskit-aer==0.15.1
-qiskit-ibm-runtime==0.31.0
+qiskit-ibm-runtime==0.33.2
 qutip==5.0.4
 numpy==2.0.2
 
@@ -8,5 +8,5 @@ numpy==2.0.2
 setuptools
 
 # For drawing circuits, state vectors, Wigner function plots
-matplotlib==3.9.2
+matplotlib==3.9.3
 pylatexenc==2.10

--- a/tests/test_noise_model.py
+++ b/tests/test_noise_model.py
@@ -795,7 +795,7 @@ def test_multi_qumode_loss_probability(capsys):
                 if (
                     (qumode1 == 1 and qumode2 == 0)
                     or (qumode1 == 0 and qumode1 == 1)
-                    and math.isclose(probability, 0.5, 0.03)
+                    and math.isclose(probability, 0.5, 0.05)
                 ):
                     fifty_fifty = True
 


### PR DESCRIPTION
Upgrade Qiskit to remove Qiskit-internal deprecation warnings from v1.2.4. However, we're trading for new internal deprecation warnings in v1.3.0.

Remove one deprecation warning caused by our own code.