### PR TITLE
Updating python versions in workflows to include 3.13

### DIFF
--- a/.github/workflows/jupyter-matrix.yml
+++ b/.github/workflows/jupyter-matrix.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+          check-latest: true
 
       - name: Setup ffmpeg (with retries)
         uses: ./.github/actions/setup-ffmpeg

--- a/.github/workflows/jupyter-matrix.yml
+++ b/.github/workflows/jupyter-matrix.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: '3.x'
 
       - name: Setup ffmpeg (with retries)
         uses: ./.github/actions/setup-ffmpeg

--- a/.github/workflows/pydoctor.yml
+++ b/.github/workflows/pydoctor.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
+        check-latest: true
 
     - name: Install requirements for documentation generation
       run: |

--- a/.github/workflows/pydoctor.yml
+++ b/.github/workflows/pydoctor.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.12
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: '3.x'
 
     - name: Install requirements for documentation generation
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: ilammy/msvc-dev-cmd@v1
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,6 +26,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python dependencies
+      uses: ilammy/msvc-dev-cmd@v1
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,13 +20,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: ilammy/msvc-dev-cmd@v1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python dependencies
-      uses: ilammy/msvc-dev-cmd@v1
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,6 +16,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        exclude:
+          - os: windows-latest
+            python-version: "3.13"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
+        check-latest: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Updates workflows to include use of Python 3.13.

- `jupyter-matrix.yml` and `pydoctor.yml` updated for use of most up to date version of Python (`3.x`)
- `python-package.yml` updated with explicit inclusion of `3.13` for matrix in workflow
- Step names in both `jupyter-matrix.yml` and `pydoctor.yml` have been changed to `Set up Python`.

