### PR TITLE
Update classifiers list in pyproject.toml with python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ requires-python = ">=3.9"
 license = { file = "LICENSE" }
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
 ]
 dependencies = [


### PR DESCRIPTION
Addresses #143.

Per the [description of classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) in `pyproject.toml`, this PR only adds information that will make `bosonic-qiskit` package searchable on PyPi regarding the specific versions of Python.

Not including `python 3.13` in classifiers list because it is not tested against `windows` due to https://github.com/Qiskit/qiskit-aer/issues/2277.