### PR TITLE
Verification of PyPi details

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,7 +16,8 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -32,6 +33,3 @@ jobs:
       run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,13 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "qiskit==1.3.0",
-    "qiskit-aer==0.15.1",
-    "qiskit-ibm-runtime==0.33.2",
+    "qiskit==1.3.2",
+    "qiskit-aer==0.16.0",
+    "qiskit-ibm-runtime==0.34.0",
     "qutip==5.0.4",
-    "matplotlib==3.9.3",
+    "matplotlib==3.9.4",
     "pylatexenc==2.10",
-    "numpy==2.0.2",
+    "numpy==2.2.2",
 ]
 
 [project.urls]
@@ -29,7 +29,7 @@ Homepage = "https://github.com/C2QA/bosonic-qiskit"
 Issues = "https://github.com/C2QA/bosonic-qiskit/issues"
 
 [build-system]
-requires = ["setuptools >= 61.0", "setuptools-git-versioning"]
+requires = ["setuptools == 75.8.0", "setuptools-git-versioning"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "qutip==5.0.4",
     "matplotlib==3.9.4",
     "pylatexenc==2.10",
-    "numpy==2.2.2",
+    "numpy==2.0.2",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ qiskit==1.3.2
 qiskit-aer==0.16.0
 qiskit-ibm-runtime==0.34.0
 qutip==5.0.4
-numpy==2.2.2
+numpy==2.0.2
 
 # QuTiP install failing without setuptools
 setuptools==75.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-qiskit==1.3.0
-qiskit-aer==0.15.1
-qiskit-ibm-runtime==0.33.2
+qiskit==1.3.2
+qiskit-aer==0.16.0
+qiskit-ibm-runtime==0.34.0
 qutip==5.0.4
-numpy==2.0.2
+numpy==2.2.2
 
 # QuTiP install failing without setuptools
-setuptools
+setuptools==75.8.0
 
 # For drawing circuits, state vectors, Wigner function plots
-matplotlib==3.9.3
+matplotlib==3.9.4
 pylatexenc==2.10

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-jupyter==1.0.0
-pytest==8.0.2
-pylint==3.1.0
-black==24.2.0
-flake8==7.0.0
+jupyter==1.1.1
+pytest==8.3.4
+pylint==3.3.3
+black==24.10.0
+flake8==7.1.1


### PR DESCRIPTION
This pull request addresses #142 

Permissions on PyPi were provided to allow for a [trusted publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).

A trusted publisher was added (the C2QA organization and bosonic-qiskit repo) and the `.github/workflows/python-publish.yml` file was updated to the recommended way for [publishing with a trusted publisher](https://docs.pypi.org/trusted-publishers/using-a-publisher/).