### PR TITLE
Adding developer instructions and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+    -   id: flake8
+        args: [--statistics, --show-source, --verbose, --count, --select="E9,F63,F7,F82"]
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.10.0
+    hooks:
+    -   id: black

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Before using Bosonic Qiskit, first install the depencies (as above) and then act
 cd <path/to/bosonic-qiskit>
 source venv/bin/activate
 ```
+## Development
+
+When making changes to `bosonic-qiskit`, it is recommended to install developer requirements from `requirements_dev.txt` and use [pre-commit](https://pre-commit.com/#intro) to automatically apply [flake8](https://flake8.pycqa.org/en/latest/) and [black](https://black.readthedocs.io/en/stable/) upon committing code to comply with formatting and style guidelines.
+
+Use script `install-dependencies-dev.sh` to create a virtual environment called `bosonic-qiskit` and install developer requirements along with `pre-commit`.
+
+```bash
+git clone https://github.com/C2QA/bosonic-qiskit.git
+cd bosonic-qiskit
+./install-dependencies-dev.sh
+``` 
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,20 @@ source venv/bin/activate
 
 When making changes to `bosonic-qiskit`, it is recommended to install developer requirements from `requirements_dev.txt` and use [pre-commit](https://pre-commit.com/#intro) to automatically apply [flake8](https://flake8.pycqa.org/en/latest/) and [black](https://black.readthedocs.io/en/stable/) upon committing code to comply with formatting and style guidelines.
 
-Use script `install-dependencies-dev.sh` to create a virtual environment called `bosonic-qiskit` and install developer requirements along with `pre-commit`.
+Use script `install-dependencies-dev.sh` to create a virtual environment and install developer requirements along with `pre-commit`.
 
 ```bash
 git clone https://github.com/C2QA/bosonic-qiskit.git
 cd bosonic-qiskit
 ./install-dependencies-dev.sh
-source ./bosonic-qiskit/bin/activate
+source ./venv/bin/activate
 ``` 
+
+Two methods for using `pre-commit`:
+1. Run `pre-commit run --all-files` to apply `flake8` and `black` before staging code for committing.
+2. Let `pre-commit` automatically be applied upon `git commit`. If something fails, fix code to comply with `flake8` and `black`, `git add` the changed files and recommit.
+
+**Note**: `pre-commit` does not automatically add changes to a commit. Any file changes resulting from `pre-commit` need to be added for the changes to be committed.
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Use script `install-dependencies-dev.sh` to create a virtual environment called 
 git clone https://github.com/C2QA/bosonic-qiskit.git
 cd bosonic-qiskit
 ./install-dependencies-dev.sh
+source ./bosonic-qiskit/bin/activate
 ``` 
 
 ## Tutorials

--- a/install-dependencies-dev.sh
+++ b/install-dependencies-dev.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+python3 -m venv bosonic-qiskit
+source venv/bin/activate
+pip3 install -r requirements_dev.txt
+pre-commit install

--- a/install-dependencies-dev.sh
+++ b/install-dependencies-dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 python3 -m venv bosonic-qiskit
-source venv/bin/activate
+source bosonic-qiskit/bin/activate
 pip3 install -r requirements_dev.txt
 pre-commit install

--- a/install-dependencies-dev.sh
+++ b/install-dependencies-dev.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-python3 -m venv bosonic-qiskit
-source bosonic-qiskit/bin/activate
+python3 -m venv venv
+source venv/bin/activate
 pip3 install -r requirements_dev.txt
 pre-commit install

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@ pytest==8.3.4
 pylint==3.3.3
 black==24.10.0
 flake8==7.1.1
+pre-commit==4.1.0


### PR DESCRIPTION
This PR provides initial tooling and instructions for developing upon `bosonic-qiskit`.

1. Add developer instructions in `README.md`
2. Create a `install-requirements-dev.txt` script that mimics `install-requirements.txt`
3. Install `pre-commit` which applies `flake8` and `black` automatically upon commit code with `git`

