### PR TITLE
Use pip installations of bosonic-qiskit

### DIFF
--- a/.github/workflows/jupyter-matrix.yml
+++ b/.github/workflows/jupyter-matrix.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r requirements_dev.txt
+          pip install .
 
       - name: Build notebook
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,6 +30,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         pip install -r requirements.txt
+        pip install .
 
     - name: Lint with flake8
       run: |

--- a/README.md
+++ b/README.md
@@ -2,9 +2,19 @@
 
 NQI C2QA project to simulate hybrid boson-qubit systems within QisKit.
 
-## Install
+## Installation
 
-Use a Python virtual environment to install compatible version of QisKit.
+Bosonic-qiskit can be installed from PyPI:
+
+```bash
+pip install bosonic-qiskit
+```
+
+We recommend the use of a virtual environment.
+
+### Development
+
+First, checkout the code from Github and use the provided script to create a virtual environment with the necessary dependencies:
 
 ```bash
 git clone https://github.com/C2QA/bosonic-qiskit.git
@@ -12,18 +22,17 @@ cd bosonic-qiskit
 ./install-dependencies.sh
 ```
 
-### Dependency Version Compatibility
-
-The Bosonic Qiskit software has not been extensively tested with different versions of its [dependencies](requirements.txt); however, some success has been achieved with both newer and older versions of Qiskit. Do note that some features require newer versions. For example, the noise modelling requires Qiskit v0.34.2+. Using older versions will cause `ModuleNotFoudError` at runtime.
-
-## Activate Virtual Environment
-
-Before using Bosonic Qiskit, first install the depencies (as above) and then activate the Python virtual environment.
+Then, install development dependencies and bosonic-qiskit in editable mode (after activating the newly-created virtual environment)
 
 ```bash
-cd <path/to/bosonic-qiskit>
 source venv/bin/activate
+pip install -r requirements_dev.txt
+pip install -e .
 ```
+
+### Dependency Version Compatibility
+
+The Bosonic Qiskit software has not been extensively tested with different versions of its [dependencies](requirements.txt); however, some success has been achieved with both newer and older versions of Qiskit. Do note that some features require newer versions. For example, the noise modelling requires Qiskit v0.34.2+. Using older versions will cause `ModuleNotFoundError` at runtime.
 
 ## Tutorials
 

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -2,4 +2,5 @@
 
 python3 -m venv venv
 source venv/bin/activate
-pip3 install -r requirements.txt
+pip3 install -r requirements_dev.txt
+pip install -e .

--- a/tutorials/bose-hubbard/bose-hubbard.ipynb
+++ b/tutorials/bose-hubbard/bose-hubbard.ipynb
@@ -14,12 +14,8 @@
    },
    "outputs": [],
    "source": [
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
     "import os\n",
     "import sys\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)\n",
     "\n",
     "# Cheat to get MS Visual Studio Code Jupyter server to recognize Python venv\n",
     "module_path = os.path.abspath(os.path.join(\"../../venv/Lib/site-packages\"))\n",
@@ -27,11 +23,7 @@
     "    sys.path.append(module_path)\n",
     "\n",
     "import c2qa\n",
-    "import qiskit\n",
-    "import numpy as np\n",
-    "import c2qa.util as util\n",
-    "import matplotlib.pyplot as plt\n",
-    "import matplotlib"
+    "import c2qa.util as util"
    ]
   },
   {

--- a/tutorials/bosonic-qiskit-textbook/1. introduction.ipynb
+++ b/tutorials/bosonic-qiskit-textbook/1. introduction.ipynb
@@ -67,12 +67,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
     "import os\n",
     "import sys\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)\n",
     "\n",
     "# Cheat to get MS Visual Studio Code Jupyter server to recognize Python venv\n",
     "module_path = os.path.abspath(os.path.join(\"../../venv/Lib/site-packages\"))\n",

--- a/tutorials/bosonic-qiskit-textbook/2. operators.ipynb
+++ b/tutorials/bosonic-qiskit-textbook/2. operators.ipynb
@@ -106,16 +106,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
     "import os\n",
     "import sys\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)\n",
     "\n",
     "# Cheat to get MS Visual Studio Code Jupyter server to recognize Python venv\n",
     "module_path = os.path.abspath(os.path.join(\"../../venv/Lib/site-packages\"))\n",

--- a/tutorials/bosonic-qiskit-textbook/3. coherent_states.ipynb
+++ b/tutorials/bosonic-qiskit-textbook/3. coherent_states.ipynb
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-11-16T20:42:52.662508Z",
@@ -69,12 +69,8 @@
    },
    "outputs": [],
    "source": [
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
     "import os\n",
     "import sys\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)\n",
     "\n",
     "# Cheat to get MS Visual Studio Code Jupyter server to recognize Python venv\n",
     "module_path = os.path.abspath(os.path.join(\"../../venv/Lib/site-packages\"))\n",
@@ -84,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-11-16T20:42:52.680672Z",
@@ -96,12 +92,13 @@
    },
    "outputs": [],
    "source": [
-    "import c2qa\n",
-    "from IPython.display import HTML\n",
+    "import numpy as np\n",
     "import qiskit\n",
     "import qiskit.visualization\n",
+    "from IPython.display import HTML\n",
     "from matplotlib import pyplot as plt\n",
-    "import numpy as np"
+    "\n",
+    "import c2qa"
    ]
   },
   {

--- a/tutorials/bosonic-qiskit-textbook/4. wigner_distribution.ipynb
+++ b/tutorials/bosonic-qiskit-textbook/4. wigner_distribution.ipynb
@@ -131,12 +131,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
     "import os\n",
     "import sys\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)\n",
     "\n",
     "# Cheat to get MS Visual Studio Code Jupyter server to recognize Python venv\n",
     "module_path = os.path.abspath(os.path.join(\"../../venv/Lib/site-packages\"))\n",
@@ -146,17 +142,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "import c2qa\n",
-    "import qiskit\n",
     "import numpy as np\n",
+    "import qiskit\n",
+    "from matplotlib import pyplot as plt\n",
     "from scipy.stats.contingency import margins\n",
-    "from matplotlib import pyplot as plt"
+    "\n",
+    "import c2qa"
    ]
   },
   {

--- a/tutorials/bosonic-qiskit-textbook/5. gates.ipynb
+++ b/tutorials/bosonic-qiskit-textbook/5. gates.ipynb
@@ -125,16 +125,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
     "import os\n",
     "import sys\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)\n",
     "\n",
     "# Cheat to get MS Visual Studio Code Jupyter server to recognize Python venv\n",
     "module_path = os.path.abspath(os.path.join(\"../../venv/Lib/site-packages\"))\n",
@@ -144,19 +140,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "import c2qa\n",
     "import numpy as np\n",
     "import qiskit\n",
     "import qiskit.visualization\n",
     "import qiskit_aer\n",
+    "from IPython.display import HTML\n",
     "from matplotlib import pyplot as plt\n",
-    "from IPython.display import HTML"
+    "\n",
+    "import c2qa"
    ]
   },
   {

--- a/tutorials/displacement-calibration/displacement-calibration.ipynb
+++ b/tutorials/displacement-calibration/displacement-calibration.ipynb
@@ -2,16 +2,12 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
     "import os\n",
     "import sys\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)\n",
     "\n",
     "# Cheat to get MS Visual Studio Code Jupyter server to recognize Python venv\n",
     "module_path = os.path.abspath(os.path.join(\"../../venv/Lib/site-packages\"))\n",
@@ -21,19 +17,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import math\n",
     "\n",
-    "import c2qa\n",
-    "import c2qa.util\n",
-    "import c2qa.wigner\n",
     "import matplotlib.pyplot\n",
     "import numpy\n",
     "import qiskit\n",
-    "import qiskit_aer"
+    "import qiskit_aer\n",
+    "\n",
+    "import c2qa\n",
+    "import c2qa.util\n",
+    "import c2qa.wigner"
    ]
   },
   {

--- a/tutorials/jaynes-cummings-model/jaynes-cummings-dispersive.ipynb
+++ b/tutorials/jaynes-cummings-model/jaynes-cummings-dispersive.ipynb
@@ -2,23 +2,17 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "af47e6c5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
-    "import os\n",
-    "import sys\n",
     "import math\n",
     "\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)\n",
-    "\n",
-    "import c2qa\n",
     "import numpy as np\n",
-    "import qiskit"
+    "import qiskit\n",
+    "\n",
+    "import c2qa"
    ]
   },
   {

--- a/tutorials/medium_article/examples.ipynb
+++ b/tutorials/medium_article/examples.ipynb
@@ -2,29 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "f54f2757-b5fa-4650-814c-9f75a7dfc9fe",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-11-16T20:47:09.468427Z",
-     "iopub.status.busy": "2023-11-16T20:47:09.468427Z",
-     "iopub.status.idle": "2023-11-16T20:47:09.483515Z",
-     "shell.execute_reply": "2023-11-16T20:47:09.483515Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
-    "import os\n",
-    "import sys\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "a2817334-6a69-4932-89b4-7e3cbe6b2711",
    "metadata": {
     "execution": {
@@ -37,10 +15,11 @@
    "outputs": [],
    "source": [
     "# Import packages that will be used\n",
-    "import c2qa\n",
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "from qiskit import QuantumRegister, ClassicalRegister"
+    "import numpy as np\n",
+    "from qiskit import ClassicalRegister, QuantumRegister\n",
+    "\n",
+    "import c2qa"
    ]
   },
   {

--- a/tutorials/reduced-density-matrix/reduced-density-matrix.ipynb
+++ b/tutorials/reduced-density-matrix/reduced-density-matrix.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -11,13 +11,8 @@
    },
    "outputs": [],
    "source": [
-    "# The C2QA pacakge is currently not published to PyPI.\n",
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
     "import os\n",
     "import sys\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)\n",
     "\n",
     "# Cheat to get MS Visual Studio Code Jupyter server to recognize Python venv\n",
     "module_path = os.path.abspath(os.path.join(\"../../venv/Lib/site-packages\"))\n",
@@ -27,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "pycharm": {
@@ -36,9 +31,10 @@
    },
    "outputs": [],
    "source": [
-    "import c2qa\n",
     "import qiskit\n",
-    "from qiskit import QuantumCircuit"
+    "from qiskit import QuantumCircuit\n",
+    "\n",
+    "import c2qa"
    ]
   },
   {

--- a/tutorials/wigner-function/wigner-function.ipynb
+++ b/tutorials/wigner-function/wigner-function.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -10,12 +10,8 @@
    },
    "outputs": [],
    "source": [
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
     "import os\n",
     "import sys\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)\n",
     "\n",
     "# Cheat to get MS Visual Studio Code Jupyter server to recognize Python venv\n",
     "module_path = os.path.abspath(os.path.join(\"../../venv/Lib/site-packages\"))\n",

--- a/tutorials/wigner-mle/wigner-mle.ipynb
+++ b/tutorials/wigner-mle/wigner-mle.ipynb
@@ -10,12 +10,8 @@
    },
    "outputs": [],
    "source": [
-    "# To use the package locally, add the C2QA repository's root folder to the path prior to importing c2qa.\n",
     "import os\n",
     "import sys\n",
-    "module_path = os.path.abspath(os.path.join(\"../..\"))\n",
-    "if module_path not in sys.path:\n",
-    "    sys.path.append(module_path)\n",
     "\n",
     "# Cheat to get MS Visual Studio Code Jupyter server to recognize Python venv\n",
     "module_path = os.path.abspath(os.path.join(\"../../venv/Lib/site-packages\"))\n",


### PR DESCRIPTION
This PR adds instructions for installing bosonic-qiskit through pip, including editable mode for local development. Additionally, it cleans up the tutorial notebooks by removing the `sys.path.append` calls that are no longer necessary. Finally, it adds installation of the package to the automated python workflows.