### PR TITLE
Add pre-commit and alter developer instructions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+    -   id: flake8
+        args: [--statistics, --show-source, --verbose, --count, --select="E9,F63,F7,F82"]
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.10.0
+    hooks:
+    -   id: black

--- a/README.md
+++ b/README.md
@@ -4,17 +4,26 @@ NQI C2QA project to simulate hybrid boson-qubit systems within QisKit.
 
 ## Installation
 
-Bosonic-qiskit can be installed from PyPI:
+### Virtual Environment
+
+It is recommended to install bosonic-qiskit in a virtual environment:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+### PyPi Installation
+
+The easiest way to install bosonic-qiskit is through PyPi:
 
 ```bash
 pip install bosonic-qiskit
 ```
 
-We recommend the use of a virtual environment.
-
 ### Development
 
-First, checkout the code from Github and use the provided script to create a virtual environment with the necessary dependencies:
+Source code installation of bosonic-qiskit for development is possible with the `install-dependencies.sh` convenience script:
 
 ```bash
 git clone https://github.com/C2QA/bosonic-qiskit.git
@@ -22,13 +31,16 @@ cd bosonic-qiskit
 ./install-dependencies.sh
 ```
 
-Then, install development dependencies and bosonic-qiskit in editable mode (after activating the newly-created virtual environment)
+The above script does the following:
+1. Creates a virtual environment with the name `venv` and activates it.
+2. The bosonic-qiskit library is installed in editable mode with developer requirements from `requirements_dev.txt` which include tools such as `flake8`, `black`, and `pre-commit` to aid in satisfying code style and format requirements.
+3. The tool `pre-commit` is installed which automatically runs `flake8` and `black` upon the `git commit` command.
 
-```bash
-source venv/bin/activate
-pip install -r requirements_dev.txt
-pip install -e .
-```
+#### Code Style Requirements
+
+Any changes or additions to bosonic-qiskit must be `black` and `flake8` compliant. These tools can be run manually, however with `pre-commit` these tools automatically check for code style compliance when commiting code.
+If `black` shows non-compliant code formatting, changes must be be manually made and altered files must be recommitted.
+
 
 ### Dependency Version Compatibility
 

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -3,4 +3,5 @@
 python3 -m venv venv
 source venv/bin/activate
 pip3 install -r requirements_dev.txt
-pip install -e .
+pre-commit install
+pip3 install -e .

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@ pytest==8.3.4
 pylint==3.3.3
 black==24.10.0
 flake8==7.1.1
+pre-commit==4.1.0


### PR DESCRIPTION
This PR provides initial tooling and instructions for developing upon bosonic-qiskit.

1. Add developer instructions in README.md
2. Alter `install-dependencies.sh` to install `pre-commit` which applies flake8 and black automatically upon `git commit` command
3. Add `pre-commit` to `requirements_dev.txt`