### PR TITLE
Pinning python version for github actions

### DIFF
--- a/.github/workflows/jupyter-matrix.yml
+++ b/.github/workflows/jupyter-matrix.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
-          check-latest: true
+          python-version: '3.13'
+          # check-latest: true
 
       - name: Setup ffmpeg (with retries)
         uses: ./.github/actions/setup-ffmpeg

--- a/.github/workflows/pydoctor.yml
+++ b/.github/workflows/pydoctor.yml
@@ -13,8 +13,8 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
-        check-latest: true
+        python-version: '3.13'
+        # check-latest: true
 
     - name: Install requirements for documentation generation
       run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
-        check-latest: true
+        python-version: '3.13'
+        # check-latest: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Python 3.14 is available for github actions and workflows.
Many dependencies for this package are not yet compatible with python 3.14, so need to pin the version in whatever github actions to prevent use of 3.14.