### PR TITLE
Fix typo in 1. introduction.ipynb

### DIFF
--- a/tutorials/bosonic-qiskit-textbook/1. introduction.ipynb
+++ b/tutorials/bosonic-qiskit-textbook/1. introduction.ipynb
@@ -174,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The method `cv_initialize` can also create *superpositions* of Fock states. Instead of an integer for the first argument, the method can take a list of the coefficients for each Fock state, with the $i^{th}$ coefficient corresponding to Fock state $|i\\rangle$. The following piece of code initilizes the qumode to $\\frac{|{0}\\rangle+|{1}\\rangle}{\\sqrt{2}}$."
+    "The method `cv_initialize` can also create *superpositions* of Fock states. Instead of an integer for the first argument, the method can take a list of the coefficients for each Fock state, with the $i^{th}$ coefficient corresponding to Fock state $|i\\rangle$. The following piece of code initializes the qumode to $\\frac{|{0}\\rangle+|{1}\\rangle}{\\sqrt{2}}$."
    ]
   },
   {


### PR DESCRIPTION
Fix typo in 1. introduction.ipynb

```
The following piece of code initilizes the qumode
-> The following piece of code initializes the qumode
```